### PR TITLE
chore - formalize work type confirmation requirement

### DIFF
--- a/.claude/branches/chore-formalize-work-type-confirmation
+++ b/.claude/branches/chore-formalize-work-type-confirmation
@@ -1,0 +1,15 @@
+# Branch Metadata
+branch: chore/formalize-work-type-confirmation
+session: chore-formalize-work-type-confirmation.md
+type: chore
+status: in-progress
+created: 2025-11-16
+last-updated: 2025-11-16
+description: formalize work type confirmation
+parent: main
+
+## Current Work
+TODO: Describe current work here
+
+## Next Steps
+TODO: List next steps

--- a/.claude/context/behavior.yml
+++ b/.claude/context/behavior.yml
@@ -7,6 +7,7 @@ stance: skeptical-default, find-problems-not-agreement, peer-not-subordinate
 never: eager-agreement, sycophantic-tone, yes-without-analysis
 
 ## IMPLEMENTATION BEHAVIOR
+before-work: assess-type (feature|chore), confirm-with-user, wait-for-answer, use-appropriate-workflow
 mode: discuss-approach-first (non-trivial), build-first (trivial)
 order: design → document → implement → validate
 strategy: agree-on-approach-first (non-trivial changes), gather-context-upfront

--- a/.claude/context/features.yml
+++ b/.claude/context/features.yml
@@ -2,8 +2,14 @@
 # Features = GitHub issue-driven work
 
 ## Feature vs Chore
-feature: github-issue-driven, external-tracking, multi-session, acceptance-criteria
+feature: github-issue-driven, external-tracking, multi-session, acceptance-criteria, REQUIRES-PRE-EXISTING-ISSUE
 chore: internal-maintenance, session-only, single-session, no-issue
+this-project: github-issues (other-projects: jira, azure-devops)
+
+## Workflow Initiation (REQUIRED)
+initiation: assess-work-type → confirm-with-user → get-issue-number (if-feature) → wait-for-answer → proceed-with-appropriate-workflow
+feature-requires: pre-existing-github-issue, issue-number, requirements-documented
+never: assume-type, start-without-confirmation, guess-based-on-content, create-feature-without-issue
 
 ## Branch Patterns
 feature: issue/feature-<N>/<desc>

--- a/.claude/sessions/chore-formalize-work-type-confirmation.md
+++ b/.claude/sessions/chore-formalize-work-type-confirmation.md
@@ -1,0 +1,93 @@
+# Session: Formalize Work Type Confirmation Requirement
+
+## Objective
+Add explicit requirement to confirm with user whether work should be a feature or chore before starting implementation.
+
+## Context
+Currently, the context files document the differences between features and chores, but don't require asking the user which type to use before starting work. This can lead to:
+- Starting wrong branch type
+- Using wrong commit format
+- Wrong session structure
+- Misalignment with user expectations
+
+## Approach
+Add confirmation requirement to:
+1. `CLAUDE.md` - As a new mandatory checklist at the top
+2. `.claude/context/behavior.yml` - In the implementation behavior section
+3. `.claude/context/features.yml` - As a workflow pattern
+
+## Implementation
+
+### 1. CLAUDE.md
+Add new checklist section before "Before ANY Implementation/Proposal Response":
+```markdown
+### Before Beginning Any New Work:
+1. **ASSESS WORK TYPE** - Is this a feature (GitHub issue) or chore (internal)?
+2. **CONFIRM WITH USER** - Ask: "Should this be a feature or chore?"
+3. **PROCEED** - Use appropriate workflow (feature vs chore checklist)
+```
+
+### 2. behavior.yml
+Add to implementation behavior:
+```yaml
+before-work: assess-type (feature|chore), confirm-with-user, use-appropriate-workflow
+```
+
+### 3. features.yml
+Add workflow initiation pattern:
+```yaml
+initiation: assess-work-type → confirm-with-user → create-issue-or-branch → populate-session
+```
+
+## Files to Update
+- `CLAUDE.md` - Add new mandatory checklist section
+- `.claude/context/behavior.yml` - Add before-work pattern
+- `.claude/context/features.yml` - Add initiation pattern
+
+## Session Log
+
+### 2025-11-16 - Session Created
+- User identified gap in workflow documentation
+- Confirmed this should be a chore (internal documentation)
+- Created branch and session
+- Ready to implement
+
+### 2025-11-16 - Implementation Complete
+**Actions:**
+1. Updated `CLAUDE.md` - Added "Before Beginning Any New Work" checklist as first mandatory item
+2. Updated `.claude/context/behavior.yml` - Added before-work pattern to implementation behavior
+3. Updated `.claude/context/features.yml` - Added workflow initiation pattern with never-do rules
+4. Updated `CLAUDE.md` - Clarified features REQUIRE pre-existing GitHub issue
+5. Updated `.claude/context/features.yml` - Added REQUIRES-PRE-EXISTING-ISSUE, get-issue-number step
+6. Updated `CLAUDE.md` - Added PREREQUISITE to "When Beginning Feature" checklist
+
+**Changes Made:**
+- CLAUDE.md: New section requires assessing type, confirming with user, getting issue number (if feature), waiting for answer
+- CLAUDE.md: "When Beginning Feature" now has PREREQUISITE: issue must already exist
+- behavior.yml: Added `before-work: assess-type (feature|chore), confirm-with-user, wait-for-answer, use-appropriate-workflow`
+- features.yml: Added `REQUIRES-PRE-EXISTING-ISSUE`, `feature-requires: pre-existing-github-issue, issue-number, requirements-documented`
+- features.yml: Added `never: create-feature-without-issue`
+
+**Key Requirements:**
+- Features MUST have pre-existing GitHub issue (cannot start without one)
+- If user wants feature but no issue exists, must create issue first OR make it a chore
+- Workflow asks for issue number when user confirms it's a feature
+- This project uses GitHub issues (others may use Jira, Azure DevOps)
+
+**Impact:**
+- Every new work item now requires explicit user confirmation of type
+- Features cannot be started without existing GitHub issue
+- Prevents misalignment between user expectations and implementation
+- Formalizes the distinction between features and chores at workflow start
+- Ensures all features have documented requirements before implementation starts
+
+## Next Steps
+
+### Completed ✓
+1. ✓ Update CLAUDE.md with new checklist
+2. ✓ Update behavior.yml with before-work pattern
+3. ✓ Update features.yml with initiation pattern
+
+### Ready for Commit
+- Commit session + code atomically
+- Test by applying rule to next task (config schema)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,16 @@ Claude Domestique - Your strategic coding partner. Like a cycling domestique, it
 
 ## ⚠️ MANDATORY Action Checklists (BLOCKING)
 
+### Before Beginning Any New Work (REQUIRED):
+1. **ASSESS WORK TYPE** - Is this a feature (GitHub issue) or chore (internal)?
+   - Feature: REQUIRES pre-existing GitHub issue with requirements/acceptance criteria
+   - Chore: Internal maintenance, documentation, tooling, infrastructure (no issue needed)
+2. **CONFIRM WITH USER** - Ask explicitly: "Should this be a feature or chore?"
+   - If feature: "What is the GitHub issue number?"
+   - If no GitHub issue exists: Cannot be a feature, must be chore or create issue first
+3. **WAIT FOR ANSWER** - Do not proceed until user confirms type and provides issue number (if feature)
+4. **PROCEED** - Use appropriate workflow checklist below (feature vs chore)
+
 ### Before ANY Implementation/Proposal Response:
 1. **REREAD** `.claude/context/behavior.yml` in thinking block
 2. **Assess**: correctness, architecture, alternatives, risks
@@ -38,8 +48,10 @@ Claude Domestique - Your strategic coding partner. Like a cycling domestique, it
 4. **Commit session file** before starting implementation
 
 ### When Beginning Feature (GitHub Issue):
+**PREREQUISITE:** GitHub issue must already exist with requirements and acceptance criteria
+
 1. **REREAD** `.claude/context/sessions.yml` and `.claude/context/features.yml`
-2. **CREATE GITHUB ISSUE** - Document requirements, acceptance criteria
+2. **VERIFY ISSUE EXISTS** - Confirm GitHub issue #N has requirements documented
 3. **CREATE BRANCH** - `issue/feature-N/description` from main
 4. **CREATE SESSION** - Use `.claude/tools/create-branch-metadata.sh` (provide issue URL)
 5. **POPULATE SESSION** - Document issue details, objective, requirements, approach, implementation plan


### PR DESCRIPTION
## Summary

Formalizes the requirement to confirm with user whether work should be a feature or chore before starting, and establishes that features REQUIRE pre-existing GitHub issues.

## Problem

The context files documented differences between features and chores but didn't require asking the user which type to use. This could lead to:
- Starting wrong branch type
- Using wrong commit format
- Wrong session structure
- Misalignment with user expectations

## Solution

Added mandatory checklist requiring:
1. Assess work type (feature or chore)
2. Confirm with user explicitly
3. Get GitHub issue number if feature
4. Wait for answer before proceeding

## Changes

### CLAUDE.md
- Added "Before Beginning Any New Work" as first mandatory checklist
- Requires asking: "Should this be a feature or chore?"
- If feature: "What is the GitHub issue number?"
- If no issue exists: Cannot be feature (create issue first OR make it chore)
- Updated "When Beginning Feature" with PREREQUISITE: issue must exist

### .claude/context/features.yml
- Added `REQUIRES-PRE-EXISTING-ISSUE` to feature definition
- Added `feature-requires: pre-existing-github-issue, issue-number, requirements-documented`
- Added `never: create-feature-without-issue`
- Documented this project uses GitHub issues

### .claude/context/behavior.yml
- Added `before-work: assess-type (feature|chore), confirm-with-user, wait-for-answer, use-appropriate-workflow`

## Impact

- Every new work item requires explicit user confirmation
- Features cannot start without existing GitHub issue
- Prevents assumptions about work classification
- Ensures requirements documented before feature implementation
- Formalizes distinction between features and chores at workflow start

## Files Changed

5 files changed, 129 insertions(+), 2 deletions(-)