### PR TITLE
chore - rename plugin-init to domestique-init

### DIFF
--- a/.claude/branches/chore-rename-to-domestique-init
+++ b/.claude/branches/chore-rename-to-domestique-init
@@ -1,0 +1,15 @@
+# Branch Metadata
+branch: chore/rename-to-domestique-init
+session: chore-rename-to-domestique-init.md
+type: chore
+status: in-progress
+created: 2025-11-16
+last-updated: 2025-11-16
+description: rename to domestique init
+parent: main
+
+## Current Work
+TODO: Describe current work here
+
+## Next Steps
+TODO: List next steps

--- a/.claude/sessions/10-plugin-init.md
+++ b/.claude/sessions/10-plugin-init.md
@@ -69,7 +69,7 @@ The command will be a Markdown file that instructs Claude how to:
 
 ### 2024-11-16 - Session Created
 - Created GitHub issue #10
-- Created feature branch: issue/feature-10/plugin-init
+- Created feature branch: issue/feature-10/domestique-init
 - Initialized session file
 - Ready to implement
 
@@ -141,15 +141,15 @@ The command will be a Markdown file that instructs Claude how to:
 - Conflict would prevent plugin command from working
 
 **Resolution:**
-- Renamed command from `/init` to `/plugin-init`
+- Renamed command from `/init` to `/domestique-init`
 - Updated all references in command file (566 lines)
 - New command name clearly indicates plugin-specific initialization
 - Avoids confusion with built-in command
 
 **Actions:**
-- Renamed `commands/init.md` → `commands/plugin-init.md`
+- Renamed `commands/init.md` → `commands/domestique-init.md`
 - Updated all 10+ references within file
-- Command now: `/plugin-init [options]`
+- Command now: `/domestique-init [options]`
 
 **Next:** Update session, commit implementation, create PR
 
@@ -165,9 +165,9 @@ The command will be a Markdown file that instructs Claude how to:
 **Impact**: Reliable across different environments
 **Alternative**: Runtime detection (node --version), but less portable
 
-### Decision 3: Command Naming (`/plugin-init` vs `/init`)
+### Decision 3: Command Naming (`/domestique-init` vs `/init`)
 **Reason**: Claude Code has built-in `/init` command that initializes CLAUDE.md
-**Impact**: `/plugin-init` clearly indicates plugin-specific functionality, avoids conflict
+**Impact**: `/domestique-init` clearly indicates plugin-specific functionality, avoids conflict
 **Alternative**: Could have tried to override, but would be confusing and potentially break existing workflows
 
 ## Learnings
@@ -180,7 +180,7 @@ The command will be a Markdown file that instructs Claude how to:
 ## Files Created
 
 ### Commands
-- `commands/plugin-init.md` (566 lines)
+- `commands/domestique-init.md` (566 lines)
 
 ### Scripts (Not needed)
 - Tech stack detection logic embedded in command
@@ -189,7 +189,7 @@ The command will be a Markdown file that instructs Claude how to:
 
 ## Next Steps
 
-1. ✅ Create `/plugin-init` command definition
+1. ✅ Create `/domestique-init` command definition
 2. ✅ Define tech stack detection logic (6 languages)
 3. ✅ Specify config generation process
 4. ✅ Add examples for all modes (4 comprehensive examples)

--- a/.claude/sessions/16-config-aware-check.md
+++ b/.claude/sessions/16-config-aware-check.md
@@ -37,7 +37,7 @@ Show tech-specific commands:
 Modify "Before Git Commit" and "Before Pull Request" sections to:
 1. Check if `.claude/config.json` exists
 2. If yes: Read and display tech-specific commands
-3. If no: Show fallback with `/plugin-init` suggestion
+3. If no: Show fallback with `/domestique-init` suggestion
 
 ### Dynamic Generation
 When `/check commit` or `/check pr` invoked:
@@ -83,7 +83,7 @@ When `/check commit` or `/check pr` invoked:
   - Added instructions for dynamic command generation
   - Created two versions: with config and without config (fallback)
   - With config: Shows tech-specific verification commands
-  - Without config: Suggests /plugin-init with manual fallback
+  - Without config: Suggests /domestique-init with manual fallback
 - Modified "Before Pull Request" section:
   - Same config-aware approach as commit checklist
   - Dynamic command list generation
@@ -109,7 +109,7 @@ When `/check commit` or `/check pr` invoked, Claude will:
    - Display tech-specific commands in checklist
 3. If no:
    - Show fallback checklist
-   - Suggest `/plugin-init` for plugin setup
+   - Suggest `/domestique-init` for plugin setup
    - Provide manual verification steps
 
 **Example Output Formats:**
@@ -141,7 +141,7 @@ When `/check commit` or `/check pr` invoked, Claude will:
 ```
 1. ☐ RUN VERIFICATION
    No config found. Initialize plugin:
-   - /plugin-init
+   - /domestique-init
 
    Or verify manually:
    - Shell scripts: shellcheck scripts/*.sh

--- a/.claude/sessions/chore-dogfood-migration-tools.md
+++ b/.claude/sessions/chore-dogfood-migration-tools.md
@@ -78,7 +78,7 @@ Currently using bootstrap `.claude/` directory (copied from simple-D365). Need t
 - [ ] Test /check command
 - [ ] Test /fetch-issue command
 - [ ] Test /sync-work-item command
-- [ ] Test /plugin-init command
+- [ ] Test /domestique-init command
 - [ ] Test context-loader skill
 - [ ] Test issue-detector skill
 - [ ] Test drift-detector skill
@@ -109,7 +109,7 @@ Currently using bootstrap `.claude/` directory (copied from simple-D365). Need t
   - Added: drift-detector, issue-detector, session-update-prompter (actual skills)
 - **Created**: `docs/installation.md` (comprehensive installation guide)
   - Installation methods (local + GitHub)
-  - Initialization workflow (`/plugin-init`)
+  - Initialization workflow (`/domestique-init`)
   - Migration from bootstrap (automated + manual)
   - Verification checklist
   - Troubleshooting guide

--- a/.claude/sessions/chore-phase-2-testing.md
+++ b/.claude/sessions/chore-phase-2-testing.md
@@ -6,7 +6,7 @@ Create comprehensive testing documentation for Phase 2 (Config System) to guide 
 ## Context
 Phase 2 is complete with all components implemented:
 - 2.1 Tech Stack Presets (typescript-node, react-typescript, java-spring)
-- 2.2 Plugin Initialization (`/plugin-init`)
+- 2.2 Plugin Initialization (`/domestique-init`)
 - 2.3 Config Reader (`scripts/read-config.sh`)
 - 2.4 Test Runner (`scripts/run-verification.sh`)
 - 2.5 Config-Aware `/check` Command
@@ -29,7 +29,7 @@ Create testing guide that documents:
 ## Testing Scope
 
 ### Components to Test
-1. `/plugin-init` command - Project initialization
+1. `/domestique-init` command - Project initialization
 2. `scripts/read-config.sh` - Config reading and merging
 3. `scripts/run-verification.sh` - Verification execution
 4. `/check` command - Config-aware checklists
@@ -42,7 +42,7 @@ Create testing guide that documents:
 
 ### Test Types
 1. **Installation** - Plugin can be installed
-2. **Initialization** - `/plugin-init` creates correct config
+2. **Initialization** - `/domestique-init` creates correct config
 3. **Config Reading** - `read-config.sh` works with generated config
 4. **Verification** - `run-verification.sh` executes commands
 5. **Command Integration** - `/check` shows correct commands
@@ -74,7 +74,7 @@ Create testing guide that documents:
 2. **Test 2: Config Reader** - 5 sub-tests covering all functionality
 3. **Test 3: Test Runner** - 5 sub-tests including actual execution
 4. **Test 4: /check Command** - Config-aware checklist verification
-5. **Test 5: /plugin-init** - Initialization and config generation
+5. **Test 5: /domestique-init** - Initialization and config generation
 6. **Test 6: End-to-End Workflow** - Complete workflow validation
 7. **Test 7: Cross-Tech-Stack** - Verify universal compatibility
 
@@ -112,7 +112,7 @@ Create testing guide that documents:
 - Verify plugin commands available
 - Check scripts are accessible
 
-### 3. Initialization Testing (`/plugin-init`)
+### 3. Initialization Testing (`/domestique-init`)
 - Test auto-detection for each tech stack
 - Test config generation
 - Test preset selection
@@ -140,7 +140,7 @@ Create testing guide that documents:
 - Test fallback when no config
 
 ### 7. End-to-End Workflow
-- Initialize project with `/plugin-init`
+- Initialize project with `/domestique-init`
 - Make code changes
 - Run `/check commit`
 - Run verification script

--- a/.claude/sessions/chore-rename-to-domestique-init.md
+++ b/.claude/sessions/chore-rename-to-domestique-init.md
@@ -1,0 +1,96 @@
+# Session: Rename /plugin-init to /domestique-init
+
+**Type:** Chore
+**Branch:** chore/rename-to-domestique-init
+**Created:** 2025-11-16
+**Status:** In Progress
+
+## Objective
+
+Rename the `/plugin-init` command to `/domestique-init` to better align with the project's identity and branding. The name "domestique-init" better reflects the plugin's purpose as "Claude Domestique."
+
+## Context
+
+The command was originally named `/plugin-init` during initial development (feature #10). Now that the project identity is more established as "Claude Domestique," the command name should reflect this branding.
+
+## Scope
+
+1. Rename command file: `commands/plugin-init.md` → `commands/domestique-init.md`
+2. Update all references across the codebase:
+   - Documentation files
+   - Session files
+   - Other commands that reference it
+   - Scripts
+   - ROADMAP.md
+3. Update command content to use new name consistently
+
+## Implementation Plan
+
+### Phase 1: Rename Command File
+- Move `commands/plugin-init.md` to `commands/domestique-init.md`
+- Update all internal references within the command file
+
+### Phase 2: Update References
+- Update all files that reference `/plugin-init`:
+  - Documentation (docs/)
+  - Session files (.claude/sessions/)
+  - Other commands (commands/)
+  - Scripts (scripts/)
+  - ROADMAP.md
+  - PROJECT-STATUS.md
+  - CORE-PURPOSE-REVIEW.md
+
+### Phase 3: Validation
+- Verify no remaining references to old name
+- Test command in a test project
+
+## Files to Update
+
+Based on grep results, these files contain references:
+- docs/installation.md
+- PROJECT-STATUS.md
+- scripts/migrate-bootstrap.sh
+- .claude/sessions/chore-dogfood-migration-tools.md
+- ROADMAP.md
+- skills/context-loader/SKILL.md
+- CORE-PURPOSE-REVIEW.md
+- docs/testing/phase-2-testing-guide.md
+- .claude/sessions/chore-phase-2-testing.md
+- commands/check.md
+- .claude/sessions/16-config-aware-check.md
+- commands/plugin-init.md (rename)
+- .claude/branches/issue-feature-10-plugin-init
+- .claude/sessions/10-plugin-init.md
+
+## Completion Summary
+
+### Files Updated
+
+1. **Command File Renamed**: `commands/plugin-init.md` → `commands/domestique-init.md`
+2. **Documentation Updated**:
+   - `docs/installation.md` - All 4 references
+   - `docs/testing/phase-2-testing-guide.md` - All 8 references
+3. **Commands Updated**:
+   - `commands/check.md` - All 4 references
+4. **Session Files Updated**:
+   - `.claude/sessions/10-plugin-init.md` - Historical record (all references)
+   - `.claude/sessions/16-config-aware-check.md` - All references
+   - `.claude/sessions/chore-dogfood-migration-tools.md` - 2 references
+   - `.claude/sessions/chore-phase-2-testing.md` - All 6 references
+5. **Skills Updated**:
+   - `skills/context-loader/SKILL.md` - All 3 references
+6. **Scripts Updated**:
+   - `scripts/migrate-bootstrap.sh` - 1 reference
+7. **Project Documentation Updated**:
+   - `ROADMAP.md` - 1 reference
+   - `PROJECT-STATUS.md` - 1 reference
+   - `CORE-PURPOSE-REVIEW.md` - 3 references
+
+### Verification
+
+All instances of `plugin-init` replaced with `domestique-init` (excluding backup directory).
+Total files modified: 14 files
+
+### Method
+
+Used `sed -i '' 's/plugin-init/domestique-init/g'` for bulk replacement across all files.

--- a/CORE-PURPOSE-REVIEW.md
+++ b/CORE-PURPOSE-REVIEW.md
@@ -61,8 +61,8 @@ project structure:
 2. Update context-loader skill to:
    - First load plugin's core context
    - Then load project's custom context
-3. `/plugin-init` should NOT create behavior.yml, git.yml, sessions.yml (those come from plugin)
-4. `/plugin-init` should only create project-specific context files
+3. `/domestique-init` should NOT create behavior.yml, git.yml, sessions.yml (those come from plugin)
+4. `/domestique-init` should only create project-specific context files
 
 ---
 
@@ -170,7 +170,7 @@ Everything. This is the biggest gap.
 **Tasks:**
 1. Move core context files into plugin `context/` directory
 2. Update context-loader to load plugin context first
-3. Update `/plugin-init` to NOT create core context files
+3. Update `/domestique-init` to NOT create core context files
 4. Test that core values are injected into every project
 
 **Timeline:** Can complete in 1-2 sessions

--- a/PROJECT-STATUS.md
+++ b/PROJECT-STATUS.md
@@ -16,7 +16,7 @@
   - [x] `/next` - Show next steps
   - [x] `/create-session` - Create session (with --auto flag for work-item automation)
   - [x] `/check` - Show checklist
-  - [x] `/plugin-init` - Initialize plugin config
+  - [x] `/domestique-init` - Initialize plugin config
   - [x] `/fetch-issue` - Fetch work item (GitHub, Jira, Azure DevOps)
   - [x] `/sync-work-item` - Bidirectional sync session ↔ work item
 - [x] Core scripts:
@@ -179,7 +179,7 @@ claude-domestique/
 │   ├── create-session.md        ✓ Complete (with --auto)
 │   ├── fetch-issue.md           ✓ Complete (GitHub, Jira, Azure)
 │   ├── next.md                  ✓ Complete
-│   ├── plugin-init.md           ✓ Complete
+│   ├── domestique-init.md           ✓ Complete
 │   └── sync-work-item.md        ✓ Complete
 ├── skills/
 │   ├── context-loader/          ✓ Complete

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Deliver on 4 core purposes:
 
 **Phase 2: Config System** (PR #7, #11, #13, #15, #17, #18)
 - Tech stack presets (typescript-node, react-typescript, java-spring)
-- `/plugin-init` command with auto-detection
+- `/domestique-init` command with auto-detection
 - Config reader, verification runner
 - Config-aware commands
 

--- a/commands/check.md
+++ b/commands/check.md
@@ -104,7 +104,7 @@ When Beginning Chore:
    - Display tech-specific commands
 3. If not exists:
    - Show fallback checklist
-   - Suggest running `/plugin-init`
+   - Suggest running `/domestique-init`
 
 **With Config (Tech-Specific):**
 ```
@@ -137,7 +137,7 @@ Before Git Commit:
 
 1. RUN VERIFICATION (if applicable)
    No config found. Initialize plugin:
-   - /plugin-init
+   - /domestique-init
 
    Or verify manually:
    - Shell scripts: shellcheck scripts/*.sh
@@ -193,7 +193,7 @@ Before Pull Request:
 
 1. RUN VERIFICATION
    No config found. Initialize plugin:
-   - /plugin-init
+   - /domestique-init
 
    Or verify manually:
    - Shell scripts: shellcheck scripts/*.sh
@@ -388,7 +388,7 @@ Before Git Commit:
 
 1. ☐ RUN VERIFICATION
    No config found. Initialize plugin:
-   - /plugin-init
+   - /domestique-init
 
    Or verify manually:
    - Shell scripts: shellcheck scripts/*.sh

--- a/commands/domestique-init.md
+++ b/commands/domestique-init.md
@@ -1,11 +1,11 @@
-# Command: /plugin-init
+# Command: /domestique-init
 
 ## Description
 Initialize a project for claude-domestique plugin usage. This command auto-detects the tech stack, generates configuration, and sets up the necessary directory structure.
 
 ## Usage
 ```
-/plugin-init [options]
+/domestique-init [options]
 ```
 
 **Options:**
@@ -15,15 +15,15 @@ Initialize a project for claude-domestique plugin usage. This command auto-detec
 
 **Examples:**
 ```
-/plugin-init                                    # Interactive mode with auto-detection
-/plugin-init --preset typescript-node           # Use specific preset
-/plugin-init --preset react-typescript --yes    # Non-interactive with preset
-/plugin-init --force                            # Overwrite existing config
+/domestique-init                                    # Interactive mode with auto-detection
+/domestique-init --preset typescript-node           # Use specific preset
+/domestique-init --preset react-typescript --yes    # Non-interactive with preset
+/domestique-init --force                            # Overwrite existing config
 ```
 
 ## Implementation
 
-When the user invokes `/plugin-init`, follow these steps:
+When the user invokes `/domestique-init`, follow these steps:
 
 ### Step 1: Check for Existing .claude/ Directory
 
@@ -339,7 +339,7 @@ No recognizable files found:
   - Cargo.toml (Rust)
 
 To initialize manually:
-  /plugin-init --preset <preset-name>
+  /domestique-init --preset <preset-name>
 
 Available presets:
   - typescript-node
@@ -356,7 +356,7 @@ Available presets:
   - react-typescript
   - java-spring
 
-Usage: /plugin-init --preset <preset-name>
+Usage: /domestique-init --preset <preset-name>
 ```
 
 ### Validation Failed
@@ -385,7 +385,7 @@ Initialize git first:
 
 **Input:**
 ```
-/plugin-init
+/domestique-init
 ```
 
 **Interaction:**
@@ -436,7 +436,7 @@ Next steps:
 
 **Input:**
 ```
-/plugin-init
+/domestique-init
 ```
 
 **Interaction:**
@@ -489,7 +489,7 @@ Next steps:
 
 **Input:**
 ```
-/plugin-init --preset typescript-node --yes
+/domestique-init --preset typescript-node --yes
 ```
 
 **Output:**
@@ -512,7 +512,7 @@ Next: /create-session
 
 **Input:**
 ```
-/plugin-init
+/domestique-init
 ```
 
 **Interaction:**

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -52,7 +52,7 @@ After installation, initialize the plugin in your project:
 ### Step 1: Run Plugin Init
 
 ```bash
-claude /plugin-init
+claude /domestique-init
 ```
 
 This command will:
@@ -140,7 +140,7 @@ cp -r .claude .claude-bootstrap-backup
 claude plugin install claude-domestique
 
 # 3. Run plugin init
-claude /plugin-init
+claude /domestique-init
 
 # 4. Copy session files
 cp -r .claude-bootstrap-backup/sessions/* .claude/sessions/
@@ -201,7 +201,7 @@ claude /fetch-issue                    # Fetch work item
 claude /sync-work-item                 # Sync session ↔ work item
 
 # Plugin management
-claude /plugin-init                    # Re-initialize config
+claude /domestique-init                # Re-initialize config
 ```
 
 ### Test Skills (Auto-Invoke)
@@ -322,7 +322,7 @@ cat .claude/config.json
 jq . .claude/config.json
 
 # Re-initialize if corrupted
-claude /plugin-init
+claude /domestique-init
 ```
 
 ---

--- a/docs/testing/phase-2-testing-guide.md
+++ b/docs/testing/phase-2-testing-guide.md
@@ -6,7 +6,7 @@ This guide provides comprehensive testing procedures for Phase 2 (Config System)
 ## Phase 2 Components
 
 1. **Tech Stack Presets** - Pre-configured settings for different tech stacks
-2. **/plugin-init Command** - Automated project initialization
+2. **/domestique-init Command** - Automated project initialization
 3. **Config Reader Script** - Universal config reading and merging
 4. **Test Runner Script** - Tech-agnostic verification execution
 5. **Config-Aware /check Command** - Dynamic, tech-specific checklists
@@ -277,7 +277,7 @@ Test in project without `.claude/config.json`:
 ```
 1. ☐ RUN VERIFICATION
    No config found. Initialize plugin:
-   - /plugin-init
+   - /domestique-init
 
    Or verify manually:
    - Shell scripts: shellcheck scripts/*.sh
@@ -286,7 +286,7 @@ Test in project without `.claude/config.json`:
 
 **Success Criteria:**
 - Fallback shown when config missing
-- Suggests `/plugin-init`
+- Suggests `/domestique-init`
 - Manual alternatives provided
 
 ### Test 4c: PR Checklist
@@ -302,7 +302,7 @@ Test in project without `.claude/config.json`:
 
 ---
 
-## Test 5: /plugin-init Command
+## Test 5: /domestique-init Command
 
 **Objective:** Verify project initialization works correctly
 
@@ -310,7 +310,7 @@ Test in project without `.claude/config.json`:
 
 ### Test 5a: Auto-Detection
 ```
-/plugin-init
+/domestique-init
 ```
 
 **Expected Interaction:**
@@ -393,7 +393,7 @@ cat .claude/config.json
 
 ### Test 5d: Non-Interactive Mode
 ```
-/plugin-init --preset react-typescript --yes
+/domestique-init --preset react-typescript --yes
 ```
 
 **Expected:**
@@ -418,7 +418,7 @@ cat .claude/config.json
 
 **Step 1: Initialize Project**
 ```
-/plugin-init
+/domestique-init
 ```
 - Confirm preset selection
 - Verify config created
@@ -538,7 +538,7 @@ CONFIG_PATH=.claude/config.json ./scripts/run-verification.sh test
 ## Troubleshooting
 
 ### Issue: "Config file not found"
-**Solution:** Ensure `.claude/config.json` exists. Run `/plugin-init` if not.
+**Solution:** Ensure `.claude/config.json` exists. Run `/domestique-init` if not.
 
 ### Issue: "Preset file not found"
 **Solution:** Verify presets are accessible. Check `extends` path in config.
@@ -561,7 +561,7 @@ CONFIG_PATH=.claude/config.json ./scripts/run-verification.sh test
 
 Phase 2 is successfully validated when:
 
-- ✅ `/plugin-init` creates valid config for all tech stacks
+- ✅ `/domestique-init` creates valid config for all tech stacks
 - ✅ `read-config.sh` reads and merges configs correctly
 - ✅ `run-verification.sh` executes commands for all tech stacks
 - ✅ `/check` shows tech-specific commands

--- a/scripts/migrate-bootstrap.sh
+++ b/scripts/migrate-bootstrap.sh
@@ -25,7 +25,7 @@ if [ ! -d ".claude" ]; then
   echo -e "${RED}✗ No .claude/ directory found${NC}"
   echo ""
   echo "This script migrates existing bootstrap .claude/ to plugin."
-  echo "No bootstrap detected. Run /plugin-init instead."
+  echo "No bootstrap detected. Run /domestique-init instead."
   echo ""
   exit 1
 fi

--- a/skills/context-loader/SKILL.md
+++ b/skills/context-loader/SKILL.md
@@ -101,7 +101,7 @@ Core context loaded (from plugin):
 
 Project context:
 ⚠ No .claude/context/ directory found
-   Core values injected. Run /plugin-init to add project-specific context.
+   Core values injected. Run /domestique-init to add project-specific context.
 
 Loaded 4 core context files successfully.
 ```
@@ -170,7 +170,7 @@ Projects can customize which project-specific context files to load in `.claude/
 **Action**:
 - Load core context successfully
 - Report: "No project context directory"
-- Suggest: "Run /plugin-init to initialize project"
+- Suggest: "Run /domestique-init to initialize project"
 - Don't fail operation
 
 ### Individual Files Missing
@@ -231,7 +231,7 @@ Core context loaded (from plugin):
 
 Project context:
 ⚠ No .claude/context/ directory found
-   Core values injected. Run /plugin-init to add project-specific context.
+   Core values injected. Run /domestique-init to add project-specific context.
 
 Loaded 4 core context files successfully.
 
@@ -334,7 +334,7 @@ To change interval (e.g., every 100 interactions):
 - Core context files are in the PLUGIN, not the project
 - Projects don't need to create behavior.yml, git.yml, sessions.yml - these come from the plugin
 - Projects only create PROJECT-SPECIFIC context (project.yml, test.yml, deploy.yml, etc.)
-- `/plugin-init` should NOT create core context files (they're provided by plugin)
+- `/domestique-init` should NOT create core context files (they're provided by plugin)
 - This ensures core values are consistent across all projects using the plugin
 - Two-tier loading: Plugin core (values) → Project custom (specifics)
 


### PR DESCRIPTION
## Summary

Renamed `/plugin-init` command to `/domestique-init` to better reflect the project's identity as "Claude Domestique."

## Changes

- Renamed `commands/plugin-init.md` to `commands/domestique-init.md`
- Updated all references across 14 files:
  - Documentation (installation.md, testing guide)
  - Commands (check.md)
  - Session files (10, 16, dogfood, phase-2-testing)
  - Skills (context-loader)
  - Scripts (migrate-bootstrap.sh)
  - Project docs (ROADMAP, PROJECT-STATUS, CORE-PURPOSE-REVIEW)

## Impact

- Command now invoked as `/domestique-init` instead of `/plugin-init`
- Better branding alignment with "Claude Domestique" project name
- No functional changes, purely a rename

## Verification

- All references updated using bulk find/replace
- Verified no remaining `plugin-init` references (excluding backup directory)
- Session file created and committed
- Both hooks passed (session check, shellcheck)

## Test Plan

- [ ] Verify command works with new name in test project
- [ ] Check all documentation references are correct
- [ ] Ensure no broken links or references