### PR TITLE
chore - refactor CLI for testability and add coverage tests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memento",
       "source": "./memento",
       "description": "Session persistence - persist context across conversation resets with branch-based session tracking",
-      "version": "0.1.16"
+      "version": "0.1.17"
     },
     {
       "name": "mantra",

--- a/.claude/sessions/chore-remove-branch-metadata.md
+++ b/.claude/sessions/chore-remove-branch-metadata.md
@@ -1,0 +1,31 @@
+# Session: Ensure Branch Metadata Creation
+
+**Branch**: chore/remove-branch-metadata
+**Type**: chore
+**Created**: 2025-12-20
+**Status**: in-progress
+
+## Goal
+Ensure branch metadata is always created when a session file exists, even if the session was created directly via Write tool instead of `/session create`.
+
+## Session Log
+- 2025-12-20: Session created
+- 2025-12-20: Initially planned to remove branch metadata, but decided to keep it for backward compatibility
+- 2025-12-20: Added `ensureBranchMeta()` to verify-session.js to auto-create metadata
+- 2025-12-20: Tests pass (110/110)
+
+## Files Changed
+- memento/hooks/verify-session.js - Added ensureBranchMeta() function
+- memento/hooks/__tests__/session-startup.test.js
+- memento/hooks/__tests__/verify-session.test.js
+- memento/hooks/__tests__/post-edit.test.js
+- memento/scripts/__tests__/session.test.js
+- memento/hooks/session-startup.js
+- memento/hooks/post-edit.js
+- memento/jest.config.js
+
+## Next Steps
+- [x] Add auto-creation of branch metadata
+- [x] Run tests (110/110 pass)
+- [ ] Commit changes
+- [ ] Reinstall plugin to test

--- a/memento/.claude-plugin/plugin.json
+++ b/memento/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memento",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Session management for Claude Code - persist context across conversation resets with branch-based session tracking",
   "author": {
     "name": "David Puglielli"

--- a/memento/hooks/__tests__/post-edit.test.js
+++ b/memento/hooks/__tests__/post-edit.test.js
@@ -11,6 +11,7 @@ const {
   updateFilesChanged,
   processPostToolUse,
   processHook,
+  parseCliInput,
 } = require('../post-edit.js');
 
 describe('post-edit.js', () => {
@@ -177,6 +178,81 @@ describe('post-edit.js', () => {
       const result = updateFilesChanged(sessionPath, 'README.md');
       expect(result).toBe(false);
     });
+
+    it('appends Files Changed section at end when no Next Steps', () => {
+      const sessionPath = path.join(tempDir, 'session.md');
+      fs.writeFileSync(sessionPath, `# Session
+
+## Goal
+Something to do
+
+## Session Log
+- Started work
+`);
+
+      const result = updateFilesChanged(sessionPath, 'src/new-file.js');
+      expect(result).toBe(true);
+
+      const content = fs.readFileSync(sessionPath, 'utf-8');
+      expect(content).toContain('## Files Changed');
+      expect(content).toContain('- src/new-file.js');
+      // Should be at end of file
+      expect(content.trimEnd().endsWith('- src/new-file.js')).toBe(true);
+    });
+
+    it('returns false when session file write fails', () => {
+      // Use a non-existent directory to make writeFileSync fail
+      const badSessionPath = path.join(tempDir, 'nonexistent', 'dir', 'session.md');
+
+      const result = updateFilesChanged(badSessionPath, 'src/file.js');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('shouldTrackFile edge cases', () => {
+    let tempDir;
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memento-track-edge-test-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('returns false for paths that escape git root with ..', () => {
+      // Path that tries to escape the git root
+      const escapingPath = path.join(tempDir, '..', 'outside-file.js');
+      expect(shouldTrackFile(escapingPath, tempDir)).toBe(false);
+    });
+
+    it('returns false when path resolution fails', () => {
+      // Pass a path with non-existent directory to make realpathSync fail
+      const nonExistentPath = path.join(tempDir, 'non-existent-dir', 'file.js');
+      expect(shouldTrackFile(nonExistentPath, tempDir)).toBe(false);
+    });
+  });
+
+  describe('getCurrentBranch and getGitRoot', () => {
+    let tempDir;
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memento-git-test-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('getCurrentBranch returns null when not in git repo', () => {
+      const result = getCurrentBranch(tempDir);
+      expect(result).toBeNull();
+    });
+
+    it('getGitRoot returns null when not in git repo', () => {
+      const result = getGitRoot(tempDir);
+      expect(result).toBeNull();
+    });
   });
 
   describe('findSessionFile', () => {
@@ -251,6 +327,28 @@ describe('post-edit.js', () => {
       expect(result).toEqual({});
     });
 
+    it('returns empty when no file_path in tool_input', () => {
+      const result = processPostToolUse({
+        cwd: tempDir,
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Edit',
+        tool_input: {}
+      });
+
+      expect(result).toEqual({});
+    });
+
+    it('returns empty when not in git repo', () => {
+      const result = processPostToolUse({
+        cwd: tempDir,
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Edit',
+        tool_input: { file_path: path.join(tempDir, 'src/file.js') }
+      });
+
+      expect(result).toEqual({});
+    });
+
     it('ignores .claude internal files', () => {
       // Set up .claude directory with session
       const claudeDir = path.join(tempDir, '.claude');
@@ -290,6 +388,11 @@ describe('post-edit.js', () => {
     });
 
     it('does nothing on main branch', () => {
+      // Create source file that would be "edited"
+      const srcDir = path.join(tempDir, 'src');
+      fs.mkdirSync(srcDir, { recursive: true });
+      fs.writeFileSync(path.join(srcDir, 'index.js'), '// code');
+
       // Initialize git on main
       execSync('git init', { cwd: tempDir, stdio: 'pipe' });
       execSync('git config user.email "test@test.com"', { cwd: tempDir, stdio: 'pipe' });
@@ -311,6 +414,11 @@ describe('post-edit.js', () => {
     it('handles missing session gracefully', () => {
       // Set up .claude directory (no session)
       fs.mkdirSync(path.join(tempDir, '.claude', 'sessions'), { recursive: true });
+
+      // Create source file that would be "edited"
+      const srcDir = path.join(tempDir, 'src');
+      fs.mkdirSync(srcDir, { recursive: true });
+      fs.writeFileSync(path.join(srcDir, 'index.js'), '// code');
 
       // Initialize git on feature branch
       execSync('git init', { cwd: tempDir, stdio: 'pipe' });
@@ -455,6 +563,85 @@ describe('post-edit.js', () => {
       });
 
       expect(result).toEqual({});
+    });
+  });
+
+  describe('processPostToolUse edge cases', () => {
+    let tempDir;
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memento-edge-test-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('returns empty when file is already listed in session', () => {
+      // Set up .claude directory with session containing the file
+      const claudeDir = path.join(tempDir, '.claude');
+      const sessionsDir = path.join(claudeDir, 'sessions');
+      const branchesDir = path.join(claudeDir, 'branches');
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      fs.mkdirSync(branchesDir, { recursive: true });
+
+      const srcDir = path.join(tempDir, 'src');
+      fs.mkdirSync(srcDir, { recursive: true });
+      fs.writeFileSync(path.join(srcDir, 'already-listed.js'), '// code');
+
+      fs.writeFileSync(path.join(sessionsDir, 'feature-test.md'), `# Session
+
+## Files Changed
+- src/already-listed.js
+
+## Next Steps
+- [ ] Done
+`);
+      fs.writeFileSync(path.join(branchesDir, 'feature-test'), 'session: feature-test.md');
+
+      // Initialize git
+      execSync('git init', { cwd: tempDir, stdio: 'pipe' });
+      execSync('git config user.email "test@test.com"', { cwd: tempDir, stdio: 'pipe' });
+      execSync('git config user.name "Test"', { cwd: tempDir, stdio: 'pipe' });
+      fs.writeFileSync(path.join(tempDir, '.gitkeep'), '');
+      execSync('git add .gitkeep', { cwd: tempDir, stdio: 'pipe' });
+      execSync('git commit -m "init"', { cwd: tempDir, stdio: 'pipe' });
+      execSync('git checkout -b feature/test', { cwd: tempDir, stdio: 'pipe' });
+
+      const result = processPostToolUse({
+        cwd: tempDir,
+        hook_event_name: 'PostToolUse',
+        tool_name: 'Edit',
+        tool_input: { file_path: path.join(tempDir, 'src/already-listed.js') }
+      });
+
+      // Should return empty since file is already listed
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('parseCliInput', () => {
+    it('parses valid JSON input', () => {
+      const input = JSON.stringify({ cwd: '/test', tool_name: 'Edit' });
+      const result = parseCliInput(input);
+      expect(result.cwd).toBe('/test');
+      expect(result.tool_name).toBe('Edit');
+    });
+
+    it('returns default on invalid JSON', () => {
+      const result = parseCliInput('not valid json');
+      expect(result.hook_event_name).toBe('PostToolUse');
+      expect(result.cwd).toBe(process.cwd());
+    });
+
+    it('returns default on empty string', () => {
+      const result = parseCliInput('');
+      expect(result.hook_event_name).toBe('PostToolUse');
+    });
+
+    it('uses custom default event', () => {
+      const result = parseCliInput('invalid', 'CustomEvent');
+      expect(result.hook_event_name).toBe('CustomEvent');
     });
   });
 });

--- a/memento/hooks/__tests__/verify-session.test.js
+++ b/memento/hooks/__tests__/verify-session.test.js
@@ -5,10 +5,13 @@ const { execSync } = require('child_process');
 
 const {
   processPreToolUse,
+  processHook,
   sessionExists,
+  ensureBranchMeta,
   isAllowedPath,
   isFeatureBranch,
   getGitRoot,
+  parseCliInput,
   ALLOWED_PATHS
 } = require('../verify-session.js');
 
@@ -71,6 +74,14 @@ describe('verify-session.js', () => {
 
     it('blocks test files', () => {
       expect(isAllowedPath('/project/tests/unit.test.js', cwd)).toBe(false);
+    });
+
+    it('allows README.md in subdirectories', () => {
+      expect(isAllowedPath('/project/docs/README.md', cwd)).toBe(true);
+    });
+
+    it('allows package.json in subdirectories', () => {
+      expect(isAllowedPath('/project/packages/core/package.json', cwd)).toBe(true);
     });
   });
 
@@ -136,6 +147,128 @@ describe('verify-session.js', () => {
 
       expect(sessionExists(tempDir, branchInfo)).toBe(true);
     });
+
+    it('creates branch metadata when session exists but metadata does not', () => {
+      const claudeDir = path.join(tempDir, '.claude');
+      const sessionsDir = path.join(claudeDir, 'sessions');
+      const branchesDir = path.join(claudeDir, 'branches');
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      fs.mkdirSync(branchesDir, { recursive: true });
+
+      // Create session file without metadata
+      fs.writeFileSync(path.join(sessionsDir, 'feature-new.md'), '# Session');
+
+      const branchInfo = {
+        branchMetaFile: 'feature-new',
+        sessionFile: 'feature-new.md'
+      };
+
+      // Call sessionExists which should create metadata
+      expect(sessionExists(tempDir, branchInfo)).toBe(true);
+
+      // Check metadata was created
+      const metaPath = path.join(branchesDir, 'feature-new');
+      expect(fs.existsSync(metaPath)).toBe(true);
+      const content = fs.readFileSync(metaPath, 'utf-8');
+      expect(content).toContain('session: feature-new.md');
+    });
+  });
+
+  describe('ensureBranchMeta', () => {
+    let tempDir;
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memento-meta-test-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('does nothing when metadata already exists', () => {
+      const claudeDir = path.join(tempDir, '.claude');
+      const branchesDir = path.join(claudeDir, 'branches');
+      fs.mkdirSync(branchesDir, { recursive: true });
+
+      // Pre-create metadata
+      const metaPath = path.join(branchesDir, 'feature-existing');
+      fs.writeFileSync(metaPath, 'session: existing.md\nstatus: complete');
+
+      const branchInfo = {
+        branchMetaFile: 'feature-existing',
+        sessionFile: 'feature-existing.md'
+      };
+
+      ensureBranchMeta(tempDir, branchInfo);
+
+      // Verify original content unchanged
+      const content = fs.readFileSync(metaPath, 'utf-8');
+      expect(content).toContain('status: complete');
+    });
+
+    it('creates branches directory if needed', () => {
+      const claudeDir = path.join(tempDir, '.claude');
+      fs.mkdirSync(claudeDir, { recursive: true });
+      // Note: not creating branches dir
+
+      const branchInfo = {
+        branchMetaFile: 'feature-new',
+        sessionFile: 'feature-new.md'
+      };
+
+      ensureBranchMeta(tempDir, branchInfo);
+
+      const branchesDir = path.join(claudeDir, 'branches');
+      expect(fs.existsSync(branchesDir)).toBe(true);
+    });
+
+    it('creates metadata with correct content', () => {
+      const claudeDir = path.join(tempDir, '.claude');
+      const branchesDir = path.join(claudeDir, 'branches');
+      fs.mkdirSync(branchesDir, { recursive: true });
+
+      const branchInfo = {
+        branchMetaFile: 'issue-feature-42-auth',
+        sessionFile: '42-auth.md'
+      };
+
+      ensureBranchMeta(tempDir, branchInfo);
+
+      const metaPath = path.join(branchesDir, 'issue-feature-42-auth');
+      const content = fs.readFileSync(metaPath, 'utf-8');
+      expect(content).toContain('session: 42-auth.md');
+      expect(content).toContain('status: in-progress');
+    });
+  });
+
+  describe('processHook', () => {
+    let tempDir;
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memento-hook-test-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('routes PreToolUse to processPreToolUse', () => {
+      const result = processHook({
+        cwd: tempDir,
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Read',
+        tool_input: {}
+      });
+      expect(result.decision).toBe('approve');
+    });
+
+    it('approves unknown event types', () => {
+      const result = processHook({
+        cwd: tempDir,
+        hook_event_name: 'UnknownEvent'
+      });
+      expect(result.decision).toBe('approve');
+    });
   });
 
   describe('processPreToolUse', () => {
@@ -155,6 +288,17 @@ describe('verify-session.js', () => {
         hook_event_name: 'PreToolUse',
         tool_name: 'Read',
         tool_input: { file_path: '/project/src/index.js' }
+      });
+
+      expect(result.decision).toBe('approve');
+    });
+
+    it('approves when no file_path in tool_input', () => {
+      const result = processPreToolUse({
+        cwd: tempDir,
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Edit',
+        tool_input: {}
       });
 
       expect(result.decision).toBe('approve');
@@ -240,6 +384,28 @@ describe('verify-session.js', () => {
         tool_input: { file_path: path.join(tempDir, 'src/index.js') }
       });
 
+      expect(result.decision).toBe('approve');
+    });
+
+    it('approves Edit on feature branch when memento not initialized', () => {
+      // Do NOT create .claude directory - memento not initialized
+      // Initialize git on feature branch
+      execSync('git init', { cwd: tempDir, stdio: 'pipe' });
+      execSync('git config user.email "test@test.com"', { cwd: tempDir, stdio: 'pipe' });
+      execSync('git config user.name "Test"', { cwd: tempDir, stdio: 'pipe' });
+      fs.writeFileSync(path.join(tempDir, '.gitkeep'), '');
+      execSync('git add .gitkeep', { cwd: tempDir, stdio: 'pipe' });
+      execSync('git commit -m "init"', { cwd: tempDir, stdio: 'pipe' });
+      execSync('git checkout -b feature/new-feature', { cwd: tempDir, stdio: 'pipe' });
+
+      const result = processPreToolUse({
+        cwd: tempDir,
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Edit',
+        tool_input: { file_path: path.join(tempDir, 'src/index.js') }
+      });
+
+      // Should approve because memento isn't initialized (no .claude dir)
       expect(result.decision).toBe('approve');
     });
 
@@ -431,5 +597,30 @@ describe('processPreToolUse with subdirectories', () => {
 
     expect(result.decision).toBe('block');
     expect(result.reason).toContain('Session Required');
+  });
+});
+
+describe('parseCliInput', () => {
+  it('parses valid JSON input', () => {
+    const input = JSON.stringify({ cwd: '/test', tool_name: 'Edit' });
+    const result = parseCliInput(input);
+    expect(result.cwd).toBe('/test');
+    expect(result.tool_name).toBe('Edit');
+  });
+
+  it('returns default on invalid JSON', () => {
+    const result = parseCliInput('not valid json');
+    expect(result.hook_event_name).toBe('PreToolUse');
+    expect(result.cwd).toBe(process.cwd());
+  });
+
+  it('returns default on empty string', () => {
+    const result = parseCliInput('');
+    expect(result.hook_event_name).toBe('PreToolUse');
+  });
+
+  it('uses custom default event', () => {
+    const result = parseCliInput('invalid', 'CustomEvent');
+    expect(result.hook_event_name).toBe('CustomEvent');
   });
 });

--- a/memento/hooks/post-edit.js
+++ b/memento/hooks/post-edit.js
@@ -279,21 +279,36 @@ function processHook(input) {
   return {};
 }
 
+/**
+ * Parse CLI input with fallback for invalid JSON
+ * @param {string} inputData - Raw input string
+ * @param {string} defaultEvent - Default hook event name
+ * @returns {object} Parsed input object
+ */
+function parseCliInput(inputData, defaultEvent = 'PostToolUse') {
+  try {
+    return JSON.parse(inputData);
+  } catch {
+    return { cwd: process.cwd(), hook_event_name: defaultEvent };
+  }
+}
+
+/**
+ * Read all data from stdin
+ * @returns {Promise<string>} All stdin data
+ */
+async function readStdin() {
+  let data = '';
+  for await (const chunk of process.stdin) {
+    data += chunk;
+  }
+  return data;
+}
+
 // Main CLI wrapper
 async function main() {
-  let inputData = '';
-  for await (const chunk of process.stdin) {
-    inputData += chunk;
-  }
-
-  let input;
-  try {
-    input = JSON.parse(inputData);
-  } catch (e) {
-    // Fallback for direct CLI execution (testing)
-    input = { cwd: process.cwd(), hook_event_name: 'PostToolUse' };
-  }
-
+  const inputData = await readStdin();
+  const input = parseCliInput(inputData, 'PostToolUse');
   const output = processHook(input);
   console.log(JSON.stringify(output));
   process.exit(0);
@@ -308,6 +323,7 @@ module.exports = {
   updateFilesChanged,
   processPostToolUse,
   processHook,
+  parseCliInput,
 };
 
 // Run CLI if executed directly

--- a/memento/jest.config.js
+++ b/memento/jest.config.js
@@ -6,8 +6,8 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      lines: 77,
-      branches: 69,
+      lines: 90,
+      branches: 89,
     },
   },
 };

--- a/memento/package.json
+++ b/memento/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/memento",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Session management for Claude Code - persist context across conversation resets with branch-based session tracking",
   "main": "index.js",
   "scripts": {

--- a/memento/scripts/__tests__/session.test.js
+++ b/memento/scripts/__tests__/session.test.js
@@ -213,6 +213,37 @@ describe('session.js', () => {
     });
   });
 
+  describe('readBranchMeta', () => {
+    it('returns null for nonexistent branch metadata', () => {
+      const result = session.readBranchMeta('nonexistent/branch/that-does-not-exist-12345');
+      expect(result).toBe(null);
+    });
+
+    it('parses valid branch metadata file', () => {
+      // Use a branch that has metadata in this project
+      const meta = session.readBranchMeta('issue/feature-2/session-tools');
+
+      // This should find the existing metadata file
+      if (meta) {
+        expect(typeof meta).toBe('object');
+        expect(meta.session).toBe('2-session-tools.md');
+        expect(meta.type).toBe('feature');
+        expect(meta.status).toBe('in-progress');
+      }
+    });
+
+    it('parses metadata with multiple key-value pairs', () => {
+      // Test with another existing branch metadata file
+      const meta = session.readBranchMeta('chore/plugin-format');
+
+      if (meta) {
+        expect(typeof meta).toBe('object');
+        // Should parse all valid key: value lines
+        expect(Object.keys(meta).length).toBeGreaterThan(0);
+      }
+    });
+  });
+
   describe('sessionExists', () => {
     // Note: sessionExists uses hardcoded paths relative to process.cwd()
     it('returns true for existing session in project', () => {


### PR DESCRIPTION
## Summary
- Extract `parseCliInput()` from CLI main functions for unit testing
- Add `ensureBranchMeta()` to auto-create branch metadata when sessions exist
- Add comprehensive tests to reach 90% line / 89% branch coverage
- Refactor CLI code to separate stdin reading from parsing logic
- Bump memento to 0.1.17

## Test plan
- [x] All 162 tests pass
- [x] Coverage thresholds met (90% lines, 89% branches)
- [x] PR review agents found no blocking issues