### PR TITLE
chore - add session completion and version bump guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memento",
       "source": "./memento",
       "description": "Session persistence - persist context across conversation resets with branch-based session tracking",
-      "version": "0.1.17"
+      "version": "0.1.18"
     },
     {
       "name": "mantra",

--- a/.claude/branches/chore-update-session-completion-guidance
+++ b/.claude/branches/chore-update-session-completion-guidance
@@ -1,0 +1,2 @@
+session: chore-update-session-completion-guidance.md
+status: in-progress

--- a/.claude/context/project.yml
+++ b/.claude/context/project.yml
@@ -36,6 +36,14 @@ mantra: ~/.claude/mantra-state.json
 memento: ~/.claude/memento-state.json
 onus: ~/.claude/onus/state.json, ~/.claude/onus/work-item-cache.json
 
+## VERSION BUMPING
+when: plugin-functionality-or-context-changes
+ask-user: "patch, minor, or major?" (before commit)
+command: node scripts/bump-version.js <plugin> <patch|minor|major>
+major: breaking-changes
+minor: new-features, backward-compatible
+patch: bug-fixes, docs, context-updates
+
 ## SHARED CODE
 branch-parsing: memento/scripts/session.js (parseBranchName)
 convention: 1-session = 1-issue = 1-branch

--- a/.claude/sessions/chore-update-session-completion-guidance.md
+++ b/.claude/sessions/chore-update-session-completion-guidance.md
@@ -1,0 +1,26 @@
+# Session: Update Session Completion Guidance
+
+**Branch**: chore/update-session-completion-guidance
+**Type**: chore
+**Created**: 2025-12-20
+**Status**: complete
+
+## Goal
+Add guidance to memento context about when to mark sessions complete - specifically that it should happen BEFORE the final commit, not after PR merge.
+
+## Lesson Learned
+After PR merge, feature branch changes can't be pushed. So session status must be updated before the final commit/push.
+
+## Session Log
+- 2025-12-20: Session created
+- 2025-12-20: Added Session Completion section to sessions.yml
+
+## Files Changed
+- memento/context/sessions.yml - add completion timing guidance
+- .claude/context/project.yml - add version bumping guidance
+
+## Next Steps
+- [x] Update sessions.yml with completion timing
+- [x] Run tests (162/162 pass)
+- [x] Mark session complete
+- [x] Commit and PR

--- a/memento/.claude-plugin/plugin.json
+++ b/memento/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memento",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Session management for Claude Code - persist context across conversation resets with branch-based session tracking",
   "author": {
     "name": "David Puglielli"

--- a/memento/context/sessions.yml
+++ b/memento/context/sessions.yml
@@ -61,7 +61,13 @@ NEVER: edit source files before session exists
 work: implement → update session after each major task
 pause: update session file directly
 resume: switch branch → get-session.js → auto-loads correct session
-complete: mark session complete, merge PR
+complete: mark-complete → final-commit → push → PR → merge
+
+## Session Completion (CRITICAL TIMING)
+when-to-mark-complete: BEFORE final commit (not after PR merge)
+reason: feature-branch-changes-cannot-push-after-merge
+sequence: all-work-done → mark-status-complete → commit-with-session → push → create-PR
+never: try-to-update-session-after-PR-merged (branch is stale)
 
 ## Update Triggers
 when: beginning-work, after-milestone, before-pause, when-blocked, before-commit

--- a/memento/package.json
+++ b/memento/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/memento",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Session management for Claude Code - persist context across conversation resets with branch-based session tracking",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Add Session Completion section to memento sessions.yml
- Clarify: mark session complete BEFORE final commit, not after PR merge
- Add VERSION BUMPING section to project.yml (ask user patch/minor/major)
- Bump memento to 0.1.18

## Lesson Learned
After PR merge, feature branch changes can't be pushed. So session status must be updated before the final commit/push.

## Test plan
- [x] memento tests pass (162/162)