### PR TITLE
chore - add complete session warning and tdd enforcement

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,13 +8,13 @@
       "name": "memento",
       "source": "./memento",
       "description": "Session persistence - persist context across conversation resets with branch-based session tracking",
-      "version": "0.1.18"
+      "version": "0.1.19"
     },
     {
       "name": "mantra",
       "source": "./mantra",
       "description": "Context refresh - periodic re-injection of behavioral guidance to prevent context drift",
-      "version": "0.1.7"
+      "version": "0.1.8"
     },
     {
       "name": "onus",

--- a/.claude/branches/chore-new-work-detection
+++ b/.claude/branches/chore-new-work-detection
@@ -1,0 +1,4 @@
+branch: chore/new-work-detection
+session: chore-new-work-detection.md
+type: chore
+status: complete

--- a/.claude/sessions/chore-new-work-detection.md
+++ b/.claude/sessions/chore-new-work-detection.md
@@ -1,0 +1,46 @@
+# Session: new-work-detection
+
+**Branch**: chore/new-work-detection
+**Type**: chore
+**Created**: 2025-12-20
+**Status**: complete
+
+## Goal
+Enhance memento's SessionStart hook to detect when a session is complete and warn that new work requires a new branch/session.
+
+## Approach
+1. Modify SessionStart hook to check session status
+2. When status is "complete", inject warning message
+3. Add tests for the new behavior
+
+## Session Log
+- 2025-12-20: Session created
+- 2025-12-20: Identified gap - Claude proceeded with new task on completed session branch
+- 2025-12-20: Implemented complete session warning in SessionStart hook
+- 2025-12-20: Added 2 tests for the new behavior (164/164 pass)
+- 2025-12-20: Added TDD enforcement to behavior.yml and test.yml
+- 2025-12-20: All tests pass (164 memento + 85 mantra)
+
+## Key Decisions
+- Use state-based detection (session status = complete) rather than NLP-based phrase detection
+- Warning should be injected at SessionStart, not UserPromptSubmit
+
+## Learnings
+- Memento can't know when user starts new task vs. continuing current one
+- Context guidance alone wasn't sufficient - need active warning
+- TDD workflow must be enforced via MANDATORY-REREAD, not just documented
+
+## Files Changed
+- memento/hooks/session-startup.js
+- memento/hooks/__tests__/session-startup.test.js
+- mantra/context/behavior.yml
+- mantra/context/test.yml
+
+## Next Steps
+- [x] Review current SessionStart hook implementation
+- [x] Add status check and warning injection
+- [x] Add tests for complete session warning
+- [x] Run full test suite (164/164 pass)
+- [x] Add TDD enforcement to context files
+- [x] Bump versions (memento 0.1.19, mantra 0.1.8)
+- [ ] Commit and PR

--- a/mantra/.claude-plugin/plugin.json
+++ b/mantra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mantra",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Periodic context refresh for Claude Code sessions - prevents context drift by re-injecting key guidance files",
   "author": {
     "name": "David Puglielli"

--- a/mantra/context/behavior.yml
+++ b/mantra/context/behavior.yml
@@ -12,10 +12,11 @@ stance: skeptical-default, find-problems-not-agreement, peer-not-subordinate
 never: eager-agreement, sycophantic-tone, yes-without-analysis
 
 ## THINKING BLOCK REQUIREMENTS (ENFORCE CHECKLISTS)
-required-before: git-operations (commit, PR, push, merge), troubleshooting
-must-show: "Consulting [operation] checklist from git.yml"
+required-before: git-operations (commit, PR, push, merge), troubleshooting, implementation
+must-show: "Consulting [operation] checklist from git.yml" | "Consulting TDD workflow from test.yml"
 must-verify: format-requirements (PR title lowercase, commit format, zero attribution)
 enforcement: if user says "commit/PR/troubleshoot" → thinking block showing checklist verification
+enforcement: if implementing code → thinking block showing "TDD: write test first, run to fail, then implement"
 
 ## IMPLEMENTATION BEHAVIOR
 mode: discuss-approach-first (non-trivial), build-first (trivial)

--- a/mantra/context/test.yml
+++ b/mantra/context/test.yml
@@ -4,6 +4,8 @@
 # Testing Conventions - Compact Reference
 # For patterns and examples, see: test.md
 
+MANDATORY-REREAD: before-implementation (use-thinking-block-verification)
+
 ## CORE PRINCIPLES
 independent: tests run in any order, parallelizable
 deterministic: same input → same output (no flaky tests)

--- a/mantra/package.json
+++ b/mantra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/mantra",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Periodic context refresh plugin for Claude Code sessions",
   "main": "index.js",
   "bin": {

--- a/memento/.claude-plugin/plugin.json
+++ b/memento/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memento",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Session management for Claude Code - persist context across conversation resets with branch-based session tracking",
   "author": {
     "name": "David Puglielli"

--- a/memento/hooks/session-startup.js
+++ b/memento/hooks/session-startup.js
@@ -252,11 +252,26 @@ function processSessionStart(input, config = {}) {
 
   const summary = buildSessionSummary(info);
 
+  // Build additional context
+  let additionalContext = summary.context;
+
+  // Warn if session is complete - new work needs new branch/session
+  if (info.status === 'complete') {
+    additionalContext += `
+
+⚠️ **Session Complete** - This session is marked complete.
+New work requires:
+1. Create a new branch from main: \`git checkout main && git pull && git checkout -b <branch>\`
+2. Create a new session: \`/session create\`
+
+Ask the user: "Is this a new task or continuing the completed work?"`;
+  }
+
   return {
     systemMessage: summary.displayMsg,
     hookSpecificOutput: {
       hookEventName: 'SessionStart',
-      additionalContext: summary.context
+      additionalContext
     }
   };
 }

--- a/memento/package.json
+++ b/memento/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/memento",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Session management for Claude Code - persist context across conversation resets with branch-based session tracking",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Add warning to memento SessionStart when session status is complete, prompting user to create new branch/session for new work
- Add TDD enforcement to mantra context files (MANDATORY-REREAD before implementation)
- Bump memento to 0.1.19, mantra to 0.1.8

## Test plan
- [x] memento tests pass (164/164)
- [x] mantra tests pass (85/85)
- [x] Verify warning appears when starting session on completed branch
- [x] Verify TDD enforcement triggers in thinking block before implementation