### PR TITLE
#75 - add branch switch detection and self-assessment prompt

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memento",
       "source": "./memento",
       "description": "Session persistence - persist context across conversation resets with branch-based session tracking",
-      "version": "0.1.23"
+      "version": "0.1.24"
     },
     {
       "name": "mantra",

--- a/.claude/sessions/issue-feature-75-memento-hook-cleanup.md
+++ b/.claude/sessions/issue-feature-75-memento-hook-cleanup.md
@@ -1,0 +1,51 @@
+# Session: memento hook cleanup
+
+## Details
+- **Branch**: issue/feature-75/memento-hook-cleanup
+- **Type**: feature
+- **Created**: 2025-12-21
+- **Issue**: #75
+- **Status**: complete
+
+## Goal
+Minimal cleanup of memento hook: remove counter-based reminders, add branch switch detection, update status line format.
+
+Note: Issue #75 originally asked for skill delegation pattern, but PR #80 proved that doesn't work. Taking minimal approach instead.
+
+## Session Log
+- 2025-12-21: Session created
+- 2025-12-21: Chose minimal approach (option 1) after discussing skill delegation limitation
+- 2025-12-21: Implemented changes:
+  - Replaced counter logic (loadCount/saveCount) with branch tracking (loadState/saveState)
+  - Added branch switch detection
+  - Updated status line format: NEW →, SWITCHED →, or plain
+  - Added self-assessment prompt for session updates
+  - 28 tests passing
+
+## Scope (completed)
+1. Remove counter-based reminders (UPDATE_INTERVAL, count tracking, "Update Reminder" message)
+2. Add branch switch detection (save previous branch in state, compare on UserPromptSubmit)
+3. Update status line format:
+   - `📂 Memento: session-name.md` (normal)
+   - `📂 Memento: NEW → session-name.md` (new session)
+   - `📂 Memento: SWITCHED → session-name.md` (branch switch)
+
+## Files Changed
+- `memento/hooks/session-startup.js` - Removed counter, added branch switch detection
+- `memento/hooks/__tests__/session-startup.test.js` - Updated tests for new behavior
+
+## Acceptance Criteria Addressed
+From issue #75:
+- [x] Remove counter-based reminders
+- [x] Works standalone (without mantra/onus)
+- [x] Tests updated for new architecture
+- [x] Branch switch detection added
+- [x] Status line updated per architecture doc
+
+Not addressed (due to skill delegation limitation):
+- [ ] Hook reduced to ~40 LOC (139 LOC, but cleaner without counter logic)
+- [ ] Skill-based session management
+- [ ] PreCompact hook (event not available yet)
+
+## Next Steps
+1. Ready to commit

--- a/memento/.claude-plugin/plugin.json
+++ b/memento/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memento",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Session management for Claude Code - persist context across conversation resets with branch-based session tracking",
   "author": {
     "name": "David Puglielli"

--- a/memento/package.json
+++ b/memento/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/memento",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Session management for Claude Code - persist context across conversation resets with branch-based session tracking",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Remove counter-based reminders in favor of LLM self-assessment
- Add branch switch detection (tracks previous branch in state file)
- Update status line format: `NEW →`, `SWITCHED →`, or plain session name
- Add self-assessment prompt after each response for session updates
- Bump memento to 0.1.24

## Changes
| Before | After |
|--------|-------|
| Counter-based reminders (N/10) | Self-assessment prompt |
| No branch switch detection | Detects and shows SWITCHED |
| `📍 Memento: session-name (5/10)` | `📍 Memento: session-name` |

## Test plan
- [x] Run `npm test` in memento directory (28 tests pass)
- [x] Verify coverage meets thresholds (85.29% branches, 92.85% lines)