### PR TITLE
#76 - add status line alignment and crud commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
       "name": "onus",
       "source": "./onus",
       "description": "Work-item automation - fetches issues, generates commits/PRs, syncs progress",
-      "version": "0.1.7"
+      "version": "0.1.8"
     }
   ]
 }

--- a/.claude/sessions/issue-feature-76-onus-hook-cleanup.md
+++ b/.claude/sessions/issue-feature-76-onus-hook-cleanup.md
@@ -1,0 +1,52 @@
+# Session: onus-hook-cleanup
+
+## Details
+- **Branch**: issue/feature-76/onus-hook-cleanup
+- **Type**: feature
+- **Created**: 2025-12-21
+- **Issue**: #76
+- **Status**: in-progress
+
+## Goal
+Minimal cleanup + CRUD commands for onus. Issue #76 originally asked for skill delegation pattern, but PR #80 proved that doesn't work (same as #75). Taking pragmatic approach:
+
+1. **Minimal hook cleanup** - Align status line format with memento (NEW →, SWITCHED →)
+2. **CRUD commands** - Add `/onus:create`, `/onus:update`, `/onus:close` as user-invocable commands
+
+Not doing:
+- Hook reduction to ~50 LOC (skill delegation doesn't work)
+- Automatic skill handoff from hook
+
+## Session Log
+- 2025-12-21: Session created
+- 2025-12-21: Chose minimal cleanup + CRUD commands approach
+- 2025-12-21: Implemented changes:
+  - Updated status line format (NEW →, SWITCHED →, aligned with memento)
+  - Created `/onus:create` command for creating work items
+  - Created `/onus:update` command for updating/commenting
+  - Created `/onus:close` command for closing work items
+  - Updated plugin.json with new commands
+  - 52 tests passing
+
+## Files Changed
+- `onus/hooks/work-item.js` - Updated status line format
+- `onus/hooks/__tests__/work-item.test.js` - Updated tests for new format
+- `onus/commands/create.md` - New command
+- `onus/commands/update.md` - New command
+- `onus/commands/close.md` - New command
+- `onus/.claude-plugin/plugin.json` - Registered new commands
+
+## Acceptance Criteria Addressed
+From issue #76:
+- [x] Remove counter-based reminders (n/a - onus didn't have counter logic)
+- [x] Works standalone (without mantra/memento)
+- [x] Tests updated for new architecture
+- [x] Status line updated (NEW →, SWITCHED →)
+- [x] CRUD commands: create, update, close
+
+Not addressed (due to skill delegation limitation):
+- [ ] Hook reduced to ~50 LOC (637 LOC - skill delegation doesn't work)
+- [ ] PreCompact hook (event not available yet)
+
+## Next Steps
+1. Ready to commit

--- a/onus/.claude-plugin/plugin.json
+++ b/onus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onus",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Work item automation for Claude Code - fetches issues, generates commits/PRs, syncs progress",
   "author": {
     "name": "David Puglielli"
@@ -18,7 +18,10 @@
   ],
   "commands": [
     "./commands/init.md",
-    "./commands/fetch.md"
+    "./commands/fetch.md",
+    "./commands/create.md",
+    "./commands/update.md",
+    "./commands/close.md"
   ],
   "skills": "./skills/"
 }

--- a/onus/commands/close.md
+++ b/onus/commands/close.md
@@ -1,0 +1,141 @@
+---
+description: Close a work item
+argument-hint: <issue-number> [reason]
+---
+
+# Close Work Item
+
+Close an issue/work item on your configured platform.
+
+## Task
+
+Before closing, verify:
+
+1. **Acceptance criteria met** - Check all criteria are addressed
+2. **PR merged** - If code changes were involved
+3. **Reason** - Completed, Won't Fix, Duplicate, etc.
+
+## Platform Commands
+
+### GitHub Issues
+
+**Close as completed:**
+```bash
+gh issue close 42 --reason completed
+```
+
+**Close as not planned:**
+```bash
+gh issue close 42 --reason "not planned"
+```
+
+**Close with comment:**
+```bash
+gh issue close 42 --comment "Completed in PR #55"
+```
+
+### JIRA
+
+Transition to Done/Closed status:
+- Method: POST
+- URL: `https://{host}/rest/api/3/issue/PROJ-123/transitions`
+- Body: `{ "transition": { "id": "done-transition-id" } }`
+
+To find transition IDs:
+- GET `https://{host}/rest/api/3/issue/PROJ-123/transitions`
+
+### Azure DevOps
+
+Update state to Closed/Done:
+- Method: PATCH
+- URL: `https://dev.azure.com/{org}/{project}/_apis/wit/workitems/42?api-version=7.0`
+- Body:
+```json
+[
+  { "op": "add", "path": "/fields/System.State", "value": "Closed" }
+]
+```
+
+## Close Reasons
+
+| Reason | When to Use |
+|--------|-------------|
+| **Completed** | Work is done, acceptance criteria met |
+| **Duplicate** | Same as another issue (link to original) |
+| **Won't Fix** | Valid issue but won't be addressed |
+| **Invalid** | Not a real issue or works as designed |
+| **Stale** | No activity, no longer relevant |
+
+## Example Interactions
+
+### Close completed issue
+```
+User: /onus:close 42
+
+Claude: Before closing #42, let me verify:
+- PR #55 merged: Yes
+- Acceptance criteria:
+  - [x] User login works
+  - [x] Error messages display
+  - [x] Token stored securely
+
+All criteria met. Closing as completed...
+[Runs: gh issue close 42 --reason completed --comment "Completed in PR #55"]
+
+Issue #42 closed.
+```
+
+### Close as duplicate
+```
+User: /onus:close 42 duplicate
+
+Claude: Which issue is this a duplicate of?
+
+User: #38
+
+Claude: Closing as duplicate of #38...
+[Runs: gh issue close 42 --comment "Duplicate of #38"]
+
+Issue #42 closed as duplicate.
+```
+
+### Close won't fix
+```
+User: /onus:close 42 wontfix
+
+Claude: Please provide a reason for not fixing:
+
+User: Out of scope for current release
+
+Claude: Closing as not planned...
+[Runs: gh issue close 42 --reason "not planned" --comment "Out of scope for current release"]
+
+Issue #42 closed as not planned.
+```
+
+## Verification Checklist
+
+Before closing, Claude should verify:
+
+- [ ] All acceptance criteria addressed (or explicitly descoped)
+- [ ] Related PR merged (if applicable)
+- [ ] No blocking issues remain
+- [ ] Closing reason documented
+
+## Reopening
+
+If closed in error:
+
+**GitHub:**
+```bash
+gh issue reopen 42
+```
+
+**JIRA/Azure:** Use transition/state change to reopen.
+
+## Troubleshooting
+
+**Can't close?**
+- Check you have write permissions
+- JIRA: Verify the "Close" transition is available from current state
+- Some workflows require fields to be set before closing

--- a/onus/commands/create.md
+++ b/onus/commands/create.md
@@ -1,0 +1,115 @@
+---
+description: Create a new work item on issue tracker
+argument-hint: [title]
+---
+
+# Create Work Item
+
+Create a new issue/work item on your configured platform (GitHub, JIRA, or Azure DevOps).
+
+## Task
+
+**IMPORTANT: Gather information before creating.**
+
+Before creating the work item, ask the user for:
+
+### 1. Title (required)
+A concise summary of the issue/feature/task.
+
+### 2. Type (optional)
+- **feature** - New functionality
+- **bug** - Something isn't working
+- **task** - General work item
+- **chore** - Maintenance/cleanup
+
+### 3. Description (optional)
+Detailed description of the work item. Ask if they want to include:
+- Problem statement
+- Acceptance criteria
+- Technical notes
+
+### 4. Labels (optional)
+Tags to categorize the work item.
+
+## Platform Commands
+
+### GitHub Issues
+
+```bash
+gh issue create --title "Title here" --body "Description here" --label "bug,priority:high"
+```
+
+To create interactively:
+```bash
+gh issue create
+```
+
+### JIRA
+
+Use WebFetch with the JIRA REST API:
+- Method: POST
+- URL: `https://{host}/rest/api/3/issue`
+- Headers: `Authorization: Basic {JIRA_TOKEN}`, `Content-Type: application/json`
+- Body:
+```json
+{
+  "fields": {
+    "project": { "key": "PROJ" },
+    "summary": "Title here",
+    "description": { "type": "doc", "version": 1, "content": [...] },
+    "issuetype": { "name": "Task" }
+  }
+}
+```
+
+### Azure DevOps
+
+Use WebFetch with the Azure DevOps API:
+- Method: POST
+- URL: `https://dev.azure.com/{org}/{project}/_apis/wit/workitems/$Task?api-version=7.0`
+- Headers: `Authorization: Basic {AZURE_DEVOPS_TOKEN}`, `Content-Type: application/json-patch+json`
+- Body: JSON Patch format
+
+## After Creation
+
+1. Note the new issue number/key
+2. Suggest creating a branch: `git checkout -b issue/feature-{N}/{slug}`
+3. Offer to fetch the full issue details: `/onus:fetch {N}`
+
+## Example Interaction
+
+```
+User: /onus:create
+
+Claude: I'll help you create a new work item. What's the title?
+
+User: Add dark mode support
+
+Claude: Got it. What type of work item is this?
+- feature (new functionality)
+- bug (something broken)
+- task (general work)
+
+User: feature
+
+Claude: Would you like to add a description or acceptance criteria?
+
+User: Yes - should support system preference detection
+
+Claude: Creating the issue now...
+[Creates issue via gh issue create]
+
+Created issue #87: Add dark mode support
+Suggested branch: git checkout -b issue/feature-87/add-dark-mode-support
+```
+
+## Troubleshooting
+
+**Permission denied?**
+- GitHub: Ensure `GITHUB_TOKEN` has `repo` scope
+- JIRA: Ensure token has project write access
+- Azure: Ensure PAT has Work Items (Read, Write) scope
+
+**Wrong project?**
+- Check `.claude/config.json` for platform configuration
+- Run `/onus:init` to reconfigure

--- a/onus/commands/update.md
+++ b/onus/commands/update.md
@@ -1,0 +1,136 @@
+---
+description: Update work item (add comment, change status, edit fields)
+argument-hint: <issue-number> [action]
+---
+
+# Update Work Item
+
+Update an existing issue/work item on your configured platform.
+
+## Task
+
+Determine what the user wants to update:
+
+### Actions
+
+1. **Add comment** - Post a progress update or note
+2. **Change status** - Move to different state (In Progress, Done, etc.)
+3. **Edit fields** - Update title, description, labels, assignee
+4. **Check off criteria** - Mark acceptance criteria as done
+
+## Platform Commands
+
+### GitHub Issues
+
+**Add comment:**
+```bash
+gh issue comment 42 --body "Comment text here"
+```
+
+**Change status (close/reopen):**
+```bash
+gh issue close 42
+gh issue reopen 42
+```
+
+**Edit fields:**
+```bash
+gh issue edit 42 --title "New title"
+gh issue edit 42 --body "New description"
+gh issue edit 42 --add-label "in-progress"
+gh issue edit 42 --remove-label "needs-triage"
+gh issue edit 42 --add-assignee "@me"
+```
+
+### JIRA
+
+**Add comment:**
+- Method: POST
+- URL: `https://{host}/rest/api/3/issue/PROJ-123/comment`
+- Body: `{ "body": { "type": "doc", "version": 1, "content": [...] } }`
+
+**Change status (transition):**
+- Method: POST
+- URL: `https://{host}/rest/api/3/issue/PROJ-123/transitions`
+- Body: `{ "transition": { "id": "31" } }`
+
+**Edit fields:**
+- Method: PUT
+- URL: `https://{host}/rest/api/3/issue/PROJ-123`
+- Body: `{ "fields": { "summary": "New title" } }`
+
+### Azure DevOps
+
+**Add comment:**
+- Method: POST
+- URL: `https://dev.azure.com/{org}/{project}/_apis/wit/workitems/42/comments?api-version=7.0-preview.3`
+- Body: `{ "text": "Comment here" }`
+
+**Update fields:**
+- Method: PATCH
+- URL: `https://dev.azure.com/{org}/{project}/_apis/wit/workitems/42?api-version=7.0`
+- Body: JSON Patch operations
+
+## Example Interactions
+
+### Adding a comment
+```
+User: /onus:update 42 comment
+
+Claude: What would you like to comment on issue #42?
+
+User: Completed the API integration, moving to frontend work
+
+Claude: Adding comment...
+[Runs: gh issue comment 42 --body "..."]
+
+Comment added to #42.
+```
+
+### Changing status
+```
+User: /onus:update 42 status
+
+Claude: What status should I set for #42?
+Current: Open
+Options: In Progress, Done, Won't Fix
+
+User: In Progress
+
+Claude: For GitHub Issues, I'll add a label. Adding 'in-progress' label...
+[Runs: gh issue edit 42 --add-label "in-progress"]
+```
+
+### Checking off acceptance criteria
+```
+User: /onus:update 42 criteria
+
+Claude: Which acceptance criteria have been completed?
+Current criteria for #42:
+- [ ] User can log in with email/password
+- [ ] Form validates input
+- [ ] Token stored securely
+
+User: The first two are done
+
+Claude: I'll add a comment documenting progress...
+[Runs: gh issue comment 42 --body "Progress update: ..."]
+```
+
+## Bulk Updates
+
+To update multiple issues:
+```bash
+# Close all issues with a label
+gh issue list --label "duplicate" --json number -q '.[].number' | xargs -I {} gh issue close {}
+```
+
+## Troubleshooting
+
+**Can't transition issue (JIRA)?**
+- Check available transitions: GET `/rest/api/3/issue/PROJ-123/transitions`
+- Ensure you have permission for that transition
+
+**Comment failed?**
+- Verify issue exists and you have write access
+- Check authentication token is valid

--- a/onus/hooks/__tests__/work-item.test.js
+++ b/onus/hooks/__tests__/work-item.test.js
@@ -275,7 +275,7 @@ describe('work-item hook', () => {
     it('shows no issue message when no issue detected', () => {
       const state = { currentIssue: null };
       const msg = generateSessionStartMessage(state, null);
-      expect(msg).toContain('No issue detected');
+      expect(msg).toContain('no issue');
     });
 
     it('shows issue with title when available', () => {
@@ -290,8 +290,15 @@ describe('work-item hook', () => {
       const state = { currentIssue: '42' };
       const workItem = createPlaceholderWorkItem('42', 'github');
       const msg = generateSessionStartMessage(state, workItem);
-      expect(msg).toContain('42');
-      expect(msg).toContain('not fetched');
+      expect(msg).toContain('#42');
+    });
+
+    it('shows NEW indicator for new issues', () => {
+      const state = { currentIssue: '42' };
+      const workItem = createPlaceholderWorkItem('42', 'github');
+      const msg = generateSessionStartMessage(state, workItem, true);
+      expect(msg).toContain('NEW →');
+      expect(msg).toContain('#42');
     });
   });
 
@@ -299,7 +306,7 @@ describe('work-item hook', () => {
     it('shows no issue when none detected', () => {
       const state = { currentIssue: null };
       const msg = generatePromptSubmitMessage(state, null, false);
-      expect(msg).toContain('Onus: No issue');
+      expect(msg).toContain('no issue');
     });
 
     it('shows issue number when present', () => {
@@ -314,17 +321,17 @@ describe('work-item hook', () => {
       expect(msg).toContain('staged');
     });
 
-    it('shows branch switched indicator', () => {
+    it('shows SWITCHED indicator when branch changed', () => {
       const state = { currentIssue: '99' };
       const msg = generatePromptSubmitMessage(state, null, false, true);
-      expect(msg).toContain('branch switched');
+      expect(msg).toContain('SWITCHED →');
       expect(msg).toContain('#99');
     });
 
-    it('shows both branch switched and staged indicators', () => {
+    it('shows both SWITCHED and staged indicators', () => {
       const state = { currentIssue: '42' };
       const msg = generatePromptSubmitMessage(state, null, true, true);
-      expect(msg).toContain('branch switched');
+      expect(msg).toContain('SWITCHED →');
       expect(msg).toContain('staged');
     });
   });

--- a/onus/package.json
+++ b/onus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/onus",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Work item automation plugin for Claude Code - fetches issues, generates commits/PRs, syncs progress",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary

- Update status line format (NEW →, SWITCHED →) to align with memento pattern
- Add CRUD commands for work item management:
  - `/onus:create` - create new work items
  - `/onus:update` - update/comment on issues
  - `/onus:close` - close work items
- Bump version to 0.1.8

## Changes

| File | Change |
|------|--------|
| `hooks/work-item.js` | Status line format update |
| `hooks/__tests__/work-item.test.js` | Updated tests (52 passing) |
| `commands/create.md` | New command |
| `commands/update.md` | New command |
| `commands/close.md` | New command |
| `.claude-plugin/plugin.json` | Register new commands, bump version |

## Test plan

- [x] Run `npm test` in onus directory (52 tests passing)
- [x] Verify coverage acceptable (~79% statements)
- [ ] Install plugin and test commands manually