### PR TITLE
chore - refine plugin goals with flexion fundamentals

### DIFF
--- a/.claude/sessions/chore-refine-plugin-goals.md
+++ b/.claude/sessions/chore-refine-plugin-goals.md
@@ -1,0 +1,57 @@
+# Session: refine-plugin-goals
+
+## Details
+- **Branch**: chore/refine-plugin-goals
+- **Type**: chore
+- **Created**: 2025-12-22
+- **Status**: complete
+
+## Goal
+Refine plugin goals to be outcome-focused (WHAT they achieve for developers) rather than implementation-focused (HOW they work), using Flexion fundamentals as the lens.
+
+## Session Log
+- 2025-12-22: Session created
+- 2025-12-22: Discussed Flexion fundamentals alignment for each plugin
+- 2025-12-22: Updated root README.md with Flexion fundamentals framing
+- 2025-12-22: Updated mantra/README.md, memento/README.md, onus/README.md with Flexion fundamentals
+- 2025-12-22: Updated docs/research/*-analysis.md files with Flexion Fundamentals Alignment sections
+- 2025-12-22: Rewrote research recommendations with goal-focused, simplest-approach analysis
+- 2025-12-22: Added "reliability > simplicity" principle for memento (hooks essential)
+- 2025-12-22: Discovered CLAUDE.md instruction pattern from portal-D365 - best of all worlds for mantra
+
+## Key Decisions
+- Keep original clever taglines (movie references, Latin)
+- Add "Flexion Fundamentals" subsection after intro in each README
+- Each plugin maps to specific fundamentals based on what it enables
+- Research docs reframed: "what delivers value?" not "what can it do?"
+- Simplest approach: delegate to native, keep only unique plugin value
+- **memento: reliability > simplicity** — hooks essential because users don't invoke skills reliably
+- **mantra: CLAUDE.md instruction pattern** — `/mantra:init` adds read instructions to CLAUDE.md pointing to plugin's YML files; keeps 89% token savings; auto-updates when plugin updates; no hooks needed for loading
+
+## Flexion Fundamentals Mapping
+### mantra
+- Be skeptical and curious
+- Never compromise on quality
+- Listen with humility
+
+### memento
+- Lead by example
+- Empower customers to adapt
+- Design as you go
+
+### onus
+- Never compromise on quality
+- Lead by example
+- Empower customers to adapt
+
+## Files Changed
+- `README.md` - Added Flexion fundamentals to each plugin description
+- `mantra/README.md` - Added Flexion Fundamentals subsection
+- `memento/README.md` - Added Flexion Fundamentals subsection
+- `onus/README.md` - Added Flexion Fundamentals subsection
+- `docs/research/mantra-native-features-analysis.md` - Goal-focused rewrite with CLAUDE.md instruction pattern
+- `docs/research/memento-native-features-analysis.md` - Goal-focused rewrite with reliability principle
+- `docs/research/onus-native-features-analysis.md` - Goal-focused rewrite with workflow glue focus
+
+## Next Steps
+1. Create PR

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Like a cycling domestique, it carries the water, stays focused on your goals, an
 
 Like Leonard in *Memento*, Claude can't form long-term memories. Context window fills up, conversation resets, everything vanishes. **memento** gives Claude its tattoos—session files that persist decisions, progress, and context across resets.
 
-- 1 Session = 1 Issue = 1 Branch
-- Automatic context restoration on startup
-- Survives conversation resets and compaction
-- Team handoffs with full context
+Helps developers embody Flexion fundamentals across conversation boundaries:
+- **Lead by example** — Persists decisions and progress so nothing is lost to "fixed bug" amnesia
+- **Empower customers to adapt** — Enables team handoffs with full context of what was done and why
+- **Design as you go** — Captures evolving understanding as key details emerge during work
 
 ### [mantra](./mantra) — Context Refresh
 
@@ -25,10 +25,10 @@ Like Leonard in *Memento*, Claude can't form long-term memories. Context window 
 
 You've written the perfect CLAUDE.md. Claude reads it. Claude agrees. By turn 47, Claude ignores half of it. **mantra** periodically re-injects behavioral guidance before it fades into the abyss of distant tokens.
 
-- Session start and periodic refresh
-- Anti-sycophancy rules (skeptical-peer, not helpful-subordinate)
-- Evidence-based troubleshooting enforcement
-- Freshness indicator on every prompt
+Helps developers embody Flexion fundamentals throughout long sessions:
+- **Be skeptical and curious** — Keeps Claude questioning assumptions and seeking evidence, not pattern-matching
+- **Never compromise on quality** — Maintains consistent standards from turn 1 to turn 100
+- **Listen with humility** — Enforces peer-not-subordinate stance, deferring to evidence over agreement
 
 ### [onus](./onus) — Work-Item Automation
 
@@ -36,10 +36,10 @@ You've written the perfect CLAUDE.md. Claude reads it. Claude agrees. By turn 47
 
 JIRA tickets, Azure DevOps work items, commit messages, PR descriptions. The awful-but-important work that kills your flow. **onus** handles the project management bureaucracy so you can code.
 
-- Fetches issues from GitHub, JIRA, Azure DevOps
-- Auto-populates session files with requirements
-- Generates commit messages and PR descriptions
-- Bidirectional sync with trackers
+Helps developers embody Flexion fundamentals while staying in flow:
+- **Never compromise on quality** — Ensures proper commit messages, ticket updates, and PR descriptions
+- **Lead by example** — Handles PM accountability work so it actually gets done
+- **Empower customers to adapt** — Keeps stakeholders informed via trackers without breaking developer focus
 
 ---
 

--- a/docs/research/mantra-native-features-analysis.md
+++ b/docs/research/mantra-native-features-analysis.md
@@ -4,6 +4,18 @@
 
 **Key Discovery**: Claude Code's native features cover ~70% of mantra's goals. The remaining value is in sibling plugin discovery and YAML compactness. Most critically, **SessionStart fires with `source: "compact"` after compaction**, making periodic re-injection potentially unnecessary.
 
+## Flexion Fundamentals Alignment
+
+mantra's unique value enables these Flexion fundamentals:
+
+| Fundamental | How mantra Enables It |
+|-------------|----------------------|
+| **Be skeptical and curious** | Anti-sycophancy rules keep Claude questioning assumptions, not pattern-matching |
+| **Never compromise on quality** | Consistent behavioral standards from turn 1 to turn 100, preventing drift |
+| **Listen with humility** | Peer-not-subordinate stance enforced; Claude defers to evidence over agreement |
+
+Native features provide *capability* (memory loading, status line). mantra provides *behavioral guardrails* that align Claude with how Flexion developers work.
+
 ## mantra's Stated Goals
 
 From README:
@@ -85,73 +97,192 @@ This means:
 
 **Implication**: Periodic re-injection (every N prompts) may be unnecessary. Context is re-injected when it matters most: after compaction.
 
-## Proposed Architecture Revision
+## Goal-Focused Analysis
 
-### Option A: Minimal Hook (Recommended)
+The question isn't "what can mantra do?" but "what delivers the Flexion fundamentals to the installed project?"
+
+### What Actually Delivers Value
+
+| Flexion Fundamental | What Delivers It | Simplest Implementation |
+|---------------------|------------------|------------------------|
+| **Be skeptical and curious** | Anti-sycophancy rules in `behavior.yml` | Rules content, not mechanism |
+| **Never compromise on quality** | Consistent behavioral standards | Rules loaded at session start |
+| **Listen with humility** | Peer-not-subordinate rules | Rules content, not refresh frequency |
+
+**Key Insight**: The *content* (behavioral rules) delivers value. The *mechanism* (hooks, periodic refresh) is implementation overhead. A project gets the Flexion value by having the right rules loaded, not by having them refreshed every N prompts.
+
+### Native Features That Deliver This
+
+1. **`.claude/rules/*.md`** - Auto-loaded, hierarchical, path-scoped
+2. **CLAUDE.md** - Auto-loaded at session start
+3. **SessionStart(compact)** - Fires after compaction, enabling re-injection when needed
+
+### What Remains Unique to mantra
+
+1. **Sibling plugin discovery** - Loading context from memento/onus when co-installed
+2. **YAML compactness** - ~89% token reduction vs markdown prose
+3. **Curated behavioral rules** - The actual content that enforces skeptical-first, evidence-based behavior
+
+## Simplest Architecture Recommendation
+
+**Principle**: Use native features for loading; use plugin only for what native can't do.
+
+### The Update Problem
+
+When mantra ships improved behavioral rules, how do installed projects get updates?
+
+| Approach | Update Mechanism | Pros | Cons |
+|----------|-----------------|------|------|
+| **CLAUDE.md instructions** | Points to plugin path | Automatic; keeps YML compact | Requires CLAUDE.md modification |
+| **Symlink to plugin** | Automatic | No version tracking | Converts YML→MD; loses compactness |
+| **Copy with version marker** | SessionStart checks version | Explicit control | Still needs hook; manual step |
+| **PostInstall hook** | Runs on plugin update | Automatic | [Not implemented yet](https://github.com/anthropics/claude-code/issues/11240) |
+
+### Discovery: CLAUDE.md Instruction Pattern
+
+A working example from `portal-D365/CLAUDE.md` shows a simpler approach:
+
+```markdown
+## ⚠️ MANDATORY - Load Immediately (Every Session)
+
+**YOU MUST read these files in parallel on EVERY session start using a single message with multiple Read tool calls:**
+
+.claude/context/README.yml       - How to read compact YAML
+.claude/context/sessions.yml     - Session workflow & branch tracking
+.claude/context/git.yml          - Git workflow rules
+.claude/context/behavior.yml     - AI behavior/preferences
+.claude/context/test.yml         - Testing strategy
+```
+
+**How it works:**
+1. CLAUDE.md is auto-loaded by native loading (no hooks)
+2. CLAUDE.md contains instructions telling Claude to read YML files
+3. Claude complies and reads the YML files at session start
+4. YML content loaded into context (token-efficient format preserved)
+
+**Key insight:** The "loading mechanism" IS Claude following instructions. No symlinks, no hooks, just CLAUDE.md telling Claude what to read.
+
+### Recommended: Instruction-Based Distribution
+
+**`/mantra:init` adds to project's CLAUDE.md:**
+
+```markdown
+## ⚠️ MANDATORY - Mantra Context (Load Every Session)
+
+**Read these files at session start using parallel Read calls:**
+
+~/.claude/plugins/mantra@claude-domestique/context/behavior.yml
+~/.claude/plugins/mantra@claude-domestique/context/test.yml
+~/.claude/plugins/mantra@claude-domestique/context/format-guide.yml
+```
+
+**Update mechanism:**
+- Instructions point to plugin installation path
+- When plugin updates, YML files at that path change
+- Same instructions → new content loaded automatically
+
+### Implementation: `/mantra:init` Skill
+
+```javascript
+// Get plugin installation path
+const pluginsFile = path.join(os.homedir(), '.claude/plugins/installed_plugins.json');
+const plugins = JSON.parse(fs.readFileSync(pluginsFile, 'utf8'));
+const mantraPlugin = plugins.find(p => p.name === 'mantra@claude-domestique');
+
+// Read existing CLAUDE.md or create new
+const claudeMdPath = path.join(cwd, 'CLAUDE.md');
+let content = fs.existsSync(claudeMdPath) ? fs.readFileSync(claudeMdPath, 'utf8') : '';
+
+// Check if mantra section already exists
+if (content.includes('## ⚠️ MANDATORY - Mantra Context')) {
+  console.log('✅ mantra already configured in CLAUDE.md');
+  return;
+}
+
+// Add mantra section
+const mantraSection = `
+## ⚠️ MANDATORY - Mantra Context (Load Every Session)
+
+**Read these files at session start using parallel Read calls:**
+
+${mantraPlugin.path}/context/behavior.yml
+${mantraPlugin.path}/context/test.yml
+${mantraPlugin.path}/context/format-guide.yml
+`;
+
+content = mantraSection + '\n' + content;
+fs.writeFileSync(claudeMdPath, content);
+
+console.log('✅ mantra context instructions added to CLAUDE.md');
+console.log('📍 YML files will auto-update when plugin updates');
+```
+
+### Why This Is Better Than Symlinks
+
+| Aspect | Symlinks | CLAUDE.md Instructions |
+|--------|----------|------------------------|
+| **YML compactness** | ❌ Must convert to MD | ✅ Keep YML (89% token savings) |
+| **Native loading** | ✅ Auto-discovered | ✅ Via CLAUDE.md |
+| **Updates** | ✅ Automatic | ✅ Automatic |
+| **Hooks needed** | ⚠️ Health check | ❌ None for loading |
+| **Cross-platform** | ⚠️ Symlink issues | ✅ Just file paths |
+
+### Architecture After Migration
 
 ```
-Native Features:
-├── ~/.claude/rules/behavior.md      ← Behavioral rules (native loading)
-├── .claude/rules/*.md               ← Project rules (native, path-scoped)
-├── ~/.claude/statusline.sh          ← Display script (native)
-└── CLAUDE.md                        ← Project context (native)
+Native (handles automatically):
+├── CLAUDE.md                        ← Auto-loaded; contains read instructions
+└── .claude/rules/*.md               ← Project rules (auto-loaded)
 
-mantra Hook (minimal):
-├── SessionStart                     ← Inject sibling plugin context only
-└── (remove UserPromptSubmit)        ← Not needed for periodic refresh
+mantra (minimal plugin):
+├── context/*.yml                    ← Curated behavioral rules (YML preserved!)
+├── /mantra:init skill               ← Adds instructions to CLAUDE.md
+└── SessionStart hook                ← Sibling discovery only (optional)
 ```
 
-**What changes:**
-1. Move behavioral rules to `~/.claude/rules/`
-2. Use native status line for display
-3. Keep hook only for sibling plugin discovery
-4. Remove periodic refresh logic
+### Implementation Changes
 
-### Option B: Status Line + Minimal Hook
+| Current | Recommended | Rationale |
+|---------|-------------|-----------|
+| UserPromptSubmit hook for periodic refresh | **Remove** | CLAUDE.md instructions + SessionStart(compact) handles drift |
+| Hook-based context injection | **CLAUDE.md instructions** | Claude reads YML files as instructed |
+| Hook-based status display | **Native statusline** | Simpler, no hook overhead |
+| Custom context loading | **CLAUDE.md instructions** | Native loading triggers instructions |
 
-```
-~/.claude/statusline.sh              ← Shows context freshness
-mantra/hooks/context-refresh.js      ← Writes state for statusline + sibling discovery
-```
+### Migration Path
 
-Status line script reads mantra's state file to display freshness.
+1. **Immediate**: Update `/mantra:init` to add read instructions to CLAUDE.md
+2. **Short-term**: Keep context/*.yml (no conversion needed!)
+3. **Medium-term**: Simplify SessionStart hook to sibling discovery only
+4. **Long-term**: Remove UserPromptSubmit hook entirely; CLAUDE.md instructions are sufficient
 
-### Option C: Keep Current Design
+## Conclusion
 
-If periodic re-injection provides value BEYOND SessionStart(compact), keep current design but:
-1. Validate the hypothesis: Does SessionStart(compact) actually fire with full context?
-2. Add PreCompact hook to save critical state
-3. Consider reducing refresh interval since SessionStart(compact) handles major drift
+mantra's job is to deliver skeptical-first, evidence-based behavioral guardrails to projects. The **content** delivers this value—the mechanism should be as simple as possible.
 
-## Questions to Validate
+### The CLAUDE.md Instruction Pattern (Best of Both Worlds)
 
-1. **Does SessionStart(compact) re-inject CLAUDE.md?**
-   - If yes, periodic refresh is redundant
-   - If no, mantra's value is confirmed
+| Format | Token Efficiency | Native Loading | Update Mechanism |
+|--------|-----------------|----------------|------------------|
+| **YAML + Hook injection** | ✅ ~89% reduction | ❌ Requires hook | Hook injects on SessionStart |
+| **Markdown + Symlinks** | ❌ Verbose | ✅ Auto-loaded | Symlink auto-updates |
+| **YAML + CLAUDE.md instructions** | ✅ ~89% reduction | ✅ Via CLAUDE.md | ✅ Auto-updates |
 
-2. **Is YAML compactness worth maintaining?**
-   - `.claude/rules/` uses markdown (verbose)
-   - `.claude/context/` uses YAML (compact)
-   - Trade-off: token efficiency vs native features
+**Discovery**: CLAUDE.md can instruct Claude to read YML files. This preserves token efficiency AND enables native loading AND auto-updates.
 
-3. **How often does compaction actually occur?**
-   - If rare, periodic refresh has value
-   - If frequent, SessionStart(compact) is sufficient
+### Final Architecture
 
-## Recommendation
+- **Keep**: Curated behavioral rules in YML format (token-efficient!)
+- **New**: `/mantra:init` adds read instructions to project's CLAUDE.md
+- **Delegate to native**: CLAUDE.md auto-loading triggers instructions
+- **Remove**: UserPromptSubmit periodic refresh, custom hook-based injection
 
-**Short-term**: Validate whether SessionStart(compact) properly re-injects context.
-
-**If yes (SessionStart handles it)**:
-- Deprecate periodic refresh
-- Move behavioral rules to native `~/.claude/rules/`
-- Keep hook minimal (sibling discovery only)
-- Use native status line for display
-
-**If no (context lost after compact)**:
-- Keep current design
-- Add PreCompact hook to preserve critical context
-- Consider adding custom instructions to compact: `/compact preserve behavioral rules`
+**The simplest reliable mantra:**
+1. `/mantra:init` adds instructions to CLAUDE.md pointing to plugin's context/*.yml
+2. Native CLAUDE.md loading triggers the instructions
+3. Claude reads YML files as instructed (token-efficient)
+4. Plugin updates automatically propagate (same paths, new content)
+5. SessionStart hook only needed for sibling discovery (optional)
 
 ## Sources
 

--- a/docs/research/onus-native-features-analysis.md
+++ b/docs/research/onus-native-features-analysis.md
@@ -4,6 +4,18 @@
 
 **Key Discovery**: Native Claude Code has extensive work-item capabilities via `gh` CLI and MCP servers. onus provides a **convenience layer**: zero-config branch→issue mapping, automatic context injection, and multi-platform abstraction. The unique value is workflow automation, not raw capability.
 
+## Flexion Fundamentals Alignment
+
+onus's unique value enables these Flexion fundamentals:
+
+| Fundamental | How onus Enables It |
+|-------------|----------------------|
+| **Never compromise on quality** | Ensures proper commit messages, ticket updates, and PR descriptions |
+| **Lead by example** | Handles PM accountability work so it actually gets done |
+| **Empower customers to adapt** | Keeps stakeholders informed via trackers without breaking developer focus |
+
+Native tools provide *raw capability* (fetch issues, create PRs). onus provides *workflow automation* that ensures the "awful-but-important" accountability work aligns with how Flexion developers maintain quality.
+
 ## onus's Stated Goals
 
 From README:
@@ -186,48 +198,111 @@ But this requires:
 - No branch auto-detection
 - No caching
 
-## Recommendations
+## Goal-Focused Analysis
 
-### Keep onus's Core Value
+The question isn't "what can onus do?" but "what delivers the Flexion fundamentals to the installed project?"
 
-onus provides **workflow automation**:
-1. **Branch → Issue auto-detection** (unique)
-2. **Session integration** (unique with memento)
-3. **Multi-platform abstraction** (unique)
-4. **Acceptance criteria tracking** (unique)
+### What Actually Delivers Value
 
-### Potential Simplifications
+| Flexion Fundamental | What Delivers It | Simplest Implementation |
+|---------------------|------------------|------------------------|
+| **Never compromise on quality** | Proper commit format, PR descriptions | Git convention rules (could be just `.claude/rules/`) |
+| **Lead by example** | PM work actually gets done | Reminders + easy invocation (skills) |
+| **Empower customers to adapt** | Stakeholder visibility via trackers | Issue updates when milestones hit |
 
-1. **Use gh CLI directly for GitHub ops**
-   - `/onus:fetch` could wrap `gh issue view`
-   - PR creation could use `gh pr create`
+**Key Insight**: Most of onus's "quality" value is just **git conventions** (commit format, PR template). This could be delivered by `.claude/rules/git.md` without any plugin. The unique onus value is **workflow automation**: zero-friction from branch to issue context.
 
-2. **Document MCP setup for JIRA/Azure**
-   - Instead of building fetchers, document MCP setup
-   - Use MCPs for actual API calls
+### What Native Features Already Provide
 
-3. **Focus on unique value**
-   - Branch parsing
-   - Context injection
-   - Session integration
-   - Format enforcement
+| Capability | Native Solution | Sufficient? |
+|------------|-----------------|-------------|
+| Fetch GitHub issues | `gh issue view #N` | ✅ Yes |
+| Create PRs | `gh pr create` | ✅ Yes |
+| Commit with format | Manual with rules | ✅ If rules loaded |
+| JIRA/Azure fetch | MCPs (setup required) | ⚠️ Depends on MCP maturity |
 
-### Architecture Options
+### What Remains Unique to onus
 
-**Option A: Thin Wrapper (Recommended)**
-- Keep branch parsing and context injection
-- Delegate actual fetching to gh CLI / MCPs
-- Focus on workflow, not API calls
+1. **Branch → issue auto-detection** - Extract `#42` from `issue/feature-42/desc` automatically
+2. **Session integration** - Populate memento session from issue (bridges the two)
+3. **Cached issue context** - Don't re-fetch every session start
+4. **Multi-platform abstraction** - Same workflow for GitHub/JIRA/Azure
 
-**Option B: Full Integration**
-- Keep current architecture
-- Add MCP-based fetchers for JIRA/Azure
-- More complex but self-contained
+## Simplest Architecture Recommendation
 
-**Option C: Slash Commands Only**
-- Convert to slash commands
-- Use gh CLI / MCPs directly
-- Lose auto-injection on session start
+**Principle**: Delegate fetching to native tools; focus on workflow glue.
+
+### What onus Should Be
+
+```
+onus (workflow glue):
+├── Branch parsing                   ← Extract issue from branch name
+├── Issue caching                    ← Store fetched issue locally
+├── Session integration              ← Populate memento Goal/Acceptance from issue
+└── Context injection                ← SessionStart reminds about issue
+
+Skills (user-invoked):
+├── /onus:fetch                      ← Fetch issue, populate session
+├── /onus:init                       ← Setup config
+└── (future) /onus:update            ← Push comment to tracker
+```
+
+### What onus Should NOT Be
+
+| Temptation | Why Avoid |
+|------------|-----------|
+| Custom GitHub API client | `gh` CLI does this better |
+| Custom JIRA/Azure clients | MCPs do this; don't duplicate |
+| PR creation automation | `gh pr create` is native; just enforce format via rules |
+| Complex state management | Cache issue, that's it |
+
+### Git Conventions: Plugin or Native?
+
+**Current**: onus owns `git.yml` (commit format, branch naming, PR format)
+
+**Question**: Should this be onus or just `.claude/rules/git.md`?
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| Keep in onus | Packaged with workflow automation | Extra plugin just for rules |
+| Move to native rules | Simpler, native loading | Loses plugin coherence |
+
+**Recommendation**: Keep git conventions in onus context, but recognize they could work standalone. The packaging is valuable—install onus, get the full "PM accountability" workflow.
+
+### Simplest `/onus:fetch` Implementation
+
+```markdown
+# /onus:fetch skill
+
+1. Detect platform from branch or config
+2. GitHub: `gh issue view $N --json title,body,labels`
+3. JIRA/Azure: Use MCP or WebFetch
+4. Cache result in `.claude/onus/issue-$N.json`
+5. Populate memento session Goal from title
+6. Extract acceptance criteria from body
+7. Output: "📍 Issue #N loaded. Acceptance criteria tracked."
+```
+
+No custom HTTP clients. No complex auth handling. Just wrap native tools.
+
+### Migration Path
+
+1. **Immediate**: Simplify `/onus:fetch` to wrap `gh` CLI
+2. **Short-term**: Document MCP setup for JIRA/Azure instead of building fetchers
+3. **Medium-term**: Validate if SessionStart hook is needed vs just using `/onus:fetch`
+4. **Long-term**: Consider if git rules should live in onus or be standalone
+
+## Conclusion
+
+onus's job is to ensure the "awful-but-important" PM work gets done. The **workflow automation** delivers this—zero-friction from branch name to issue context to session file to properly-formatted commit.
+
+As Claude Code's native capabilities expand (gh CLI, MCPs), onus should simplify:
+
+- **Keep**: Branch→issue detection, session integration, cached context, git conventions
+- **Delegate to native**: Issue fetching (gh/MCP), PR creation (gh), status updates (gh)
+- **Avoid**: Custom API clients, complex multi-platform abstraction, duplicate capabilities
+
+The simplest onus is: parse branch → fetch with native tools → cache → integrate with memento. Everything else is optional.
 
 ## Summary Matrix
 

--- a/mantra/README.md
+++ b/mantra/README.md
@@ -8,6 +8,14 @@ Claude is brilliant. Claude is helpful. Claude also has the memory of a goldfish
 
 **mantra** solves this by periodically re-injecting key instruction files into Claude's working context—reinforcing the behavioral guidance before it fades into the abyss of distant tokens.
 
+### Flexion Fundamentals
+
+mantra helps developers embody Flexion fundamentals throughout long sessions:
+
+- **Be skeptical and curious** — Keeps Claude questioning assumptions and seeking evidence, not pattern-matching
+- **Never compromise on quality** — Maintains consistent standards from turn 1 to turn 100
+- **Listen with humility** — Enforces peer-not-subordinate stance, deferring to evidence over agreement
+
 ## Features
 
 - **Session start refresh** - Injects context immediately when sessions start, resume, or reset

--- a/memento/README.md
+++ b/memento/README.md
@@ -4,6 +4,14 @@
 
 Like Leonard in *Memento*, Claude can't form long-term memories. memento gives Claude its tattoos—session files that persist decisions, progress, and context across conversation resets.
 
+### Flexion Fundamentals
+
+memento helps developers embody Flexion fundamentals across conversation boundaries:
+
+- **Lead by example** — Persists decisions and progress so nothing is lost to "fixed bug" amnesia
+- **Empower customers to adapt** — Enables team handoffs with full context of what was done and why
+- **Design as you go** — Captures evolving understanding as key details emerge during work
+
 ## The Problem
 
 In Christopher Nolan's *Memento* (2000), Leonard Shelby suffers from anterograde amnesia—he can't form new memories. Every few minutes, his slate wipes clean. To function, he tattoos critical facts on his body and leaves himself Polaroids and notes.

--- a/onus/README.md
+++ b/onus/README.md
@@ -4,6 +4,14 @@
 
 The awful-but-important work that developers hate: JIRA tickets, Azure DevOps work items, commit messages, PR descriptions. Someone has to carry this load. Now Claude does.
 
+### Flexion Fundamentals
+
+onus helps developers embody Flexion fundamentals while staying in flow:
+
+- **Never compromise on quality** — Ensures proper commit messages, ticket updates, and PR descriptions
+- **Lead by example** — Handles PM accountability work so it actually gets done
+- **Empower customers to adapt** — Keeps stakeholders informed via trackers without breaking developer focus
+
 ## The Problem
 
 You're in flow. You've just solved an elegant problem. Now you need to:


### PR DESCRIPTION
## Summary

- Add Flexion Fundamentals subsection to root and plugin READMEs mapping each plugin to specific fundamentals
- Rewrite research docs with goal-focused analysis ("what delivers value?" not "what can it do?")
- mantra: Discovered CLAUDE.md instruction pattern - keeps YML compactness + native loading + auto-updates
- memento: Established "reliability > simplicity" principle - hooks essential because users don't invoke skills reliably
- onus: Focus on workflow glue, delegate fetching to native tools (gh CLI, MCPs)

## Key Decisions

**Flexion Fundamentals Mapping:**
- mantra: Be skeptical and curious, Never compromise on quality, Listen with humility
- memento: Lead by example, Empower customers to adapt, Design as you go
- onus: Never compromise on quality, Lead by example, Empower customers to adapt

**Architecture Recommendations:**
- mantra: `/mantra:init` adds read instructions to CLAUDE.md pointing to plugin's YML files
- memento: Hooks provide reliable session reminders (skills alone insufficient)
- onus: Thin wrapper around `gh` CLI/MCPs, focus on branch-to-issue workflow glue

## Test plan

- [ ] Review Flexion fundamentals alignment in READMEs
- [ ] Review research doc recommendations for each plugin