### PR TITLE
chore - mantra init copies companion files

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "mantra",
       "source": "./mantra",
       "description": "Context refresh - periodic re-injection of behavioral guidance to prevent context drift",
-      "version": "0.2.1"
+      "version": "0.2.2"
     },
     {
       "name": "onus",

--- a/.claude/sessions/chore-mantra-init-verbose-files.md
+++ b/.claude/sessions/chore-mantra-init-verbose-files.md
@@ -1,0 +1,22 @@
+# Session: mantra-init-verbose-files
+
+## Details
+- **Branch**: chore/mantra-init-verbose-files
+- **Type**: chore
+- **Created**: 2025-12-23
+- **Status**: complete
+
+## Goal
+Update mantra init script to copy verbose/companion markdown files alongside compact rule files.
+
+## Session Log
+- 2025-12-23: Session created
+- 2025-12-23: Updated init.js to copy companion files from context/ to .claude/context/
+- 2025-12-23: Tests pass, manual verification confirms companion files are copied
+- 2025-12-23: Fixed companion paths in rule files to use .claude/context/ prefix
+- 2025-12-23: Bumped version to 0.2.2, PR created
+
+## Files Changed
+- mantra/scripts/init.js - added companion file copying logic
+- mantra/rules/*.md - fixed companion paths to .claude/context/
+- mantra/package.json, plugin.json, marketplace.json - version bump

--- a/mantra/.claude-plugin/plugin.json
+++ b/mantra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mantra",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Behavioral rules for Claude Code sessions - native .claude/rules/ auto-loading with compact YAML frontmatter",
   "author": {
     "name": "David Puglielli"

--- a/mantra/package.json
+++ b/mantra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/mantra",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Behavioral rules for Claude Code sessions - native .claude/rules/ auto-loading",
   "main": "index.js",
   "bin": {

--- a/mantra/rules/behavior.md
+++ b/mantra/rules/behavior.md
@@ -4,7 +4,7 @@
 #
 # Assistant Behavior - Compact Reference
 
-companion: behavior.md
+companion: .claude/context/behavior.md
 
 MANDATORY-REREAD: before-implementation-proposal-response (use-thinking-block)
 

--- a/mantra/rules/context-format.md
+++ b/mantra/rules/context-format.md
@@ -4,7 +4,7 @@
 #
 # Context Module Format - Compact Reference
 
-companion: context-format.md
+companion: .claude/context/context-format.md
 
 ## Purpose
 what: modular context injection system for Claude Code

--- a/mantra/rules/format-guide.md
+++ b/mantra/rules/format-guide.md
@@ -4,7 +4,7 @@
 #
 # Format Guide - Compact Reference
 
-companion: format-guide.md
+companion: .claude/context/format-guide.md
 
 ## Reading Compact YAML
 patterns:

--- a/mantra/rules/test.md
+++ b/mantra/rules/test.md
@@ -4,7 +4,7 @@
 #
 # Testing Conventions - Compact Reference
 
-companion: test.md
+companion: .claude/context/test.md
 
 MANDATORY-REREAD: before-implementation (use-thinking-block-verification)
 


### PR DESCRIPTION
## Summary
- Update init.js to copy companion files from context/ to .claude/context/
- Fix companion paths in rule files to use explicit .claude/context/ prefix
- Bump mantra to 0.2.2

## Test plan
- [x] npm test passes
- [x] Manual test: init copies both rules and companion files
- [x] Manual test: --force updates both sets of files