### PR TITLE
chore - improve mantra status line with real token data

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "mantra",
       "source": "./mantra",
       "description": "Context refresh - periodic re-injection of behavioral guidance to prevent context drift",
-      "version": "0.2.2"
+      "version": "0.2.3"
     },
     {
       "name": "onus",

--- a/.claude/sessions/chore-improve-mantra-status-line.md
+++ b/.claude/sessions/chore-improve-mantra-status-line.md
@@ -1,0 +1,16 @@
+# Session: improve-mantra-status-line
+
+## Details
+- **Branch**: chore/improve-mantra-status-line
+- **Type**: chore
+- **Created**: 2025-12-24
+- **Status**: in-progress
+
+## Goal
+[Describe the objective]
+
+## Session Log
+- 2025-12-24: Session created
+
+## Next Steps
+1. [First task]

--- a/mantra/.claude-plugin/plugin.json
+++ b/mantra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mantra",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Behavioral rules for Claude Code sessions - native .claude/rules/ auto-loading with compact YAML frontmatter",
   "author": {
     "name": "David Puglielli"

--- a/mantra/README.md
+++ b/mantra/README.md
@@ -53,11 +53,16 @@ Once installed, rules are automatically loaded by Claude Code at session start.
 
 ### Status Line
 
-The status hook shows you:
-- **SessionStart**: `📍 Mantra: 4 rules (~850 tokens) | behavior, context-format, ...`
-- **UserPromptSubmit**: `📍 Mantra: 5 (~10% ctx) ✓` (prompt count and context fullness)
+The status hook shows real-time context usage from Claude Code's token data:
 
-When context is compacted or resumed: `📍 Mantra: 4 rules (~850 tokens) (reloaded after compaction)`
+- **SessionStart**: `📍 Mantra: 4 rules (~850 tokens) @ 8% | behavior, context-format, ...`
+- **UserPromptSubmit**: `📍 Mantra: 25% ctx ✓`
+
+**Warnings:**
+- **Startup bloat** (>35%): `⚠️ High initial context (40%) - consider trimming CLAUDE.md or rules`
+- **Drift warning** (>=70%): `📍 Mantra: 75% ctx ⚠️ drift ✓`
+
+When context is compacted or resumed: `📍 Mantra: 4 rules (~850 tokens) @ 12% (reloaded after compaction)`
 
 ### Commands
 
@@ -71,11 +76,13 @@ When context is compacted or resumed: `📍 Mantra: 4 rules (~850 tokens) (reloa
 
 Use `/mantra:make-rule` to create your own rules:
 
-1. Write a verbose, human-readable markdown file
-2. Run `/mantra:make-rule your-guide.md`
+1. Write a verbose, human-readable markdown file (e.g., `docs/code-review.md`)
+2. Run `/mantra:make-rule docs/code-review.md`
 3. Claude converts it to token-efficient frontmatter
 4. Identify which rules are CRITICAL (used sparingly)
-5. Save to `.claude/rules/your-rule.md`
+5. Save compact version to `.claude/rules/code-review.md`
+
+**What happens to the source?** The original verbose file is preserved as a "companion" - the compact rule references it via `companion: docs/code-review.md`. Claude loads the compact rules automatically but can read the companion file on-demand for detailed examples or clarification.
 
 ## Rule File Format
 

--- a/mantra/hooks/__tests__/status.test.js
+++ b/mantra/hooks/__tests__/status.test.js
@@ -70,8 +70,34 @@ describe('mantra status hook', () => {
     expect(result.systemMessage).toContain('behavior, git, test');
   });
 
-  it('handles UserPromptSubmit with freshness and context estimate', () => {
+  it('handles UserPromptSubmit with context_window data', () => {
     // Create rules
+    const rulesDir = path.join(tmpDir, '.claude', 'rules');
+    fs.mkdirSync(rulesDir, { recursive: true });
+    fs.writeFileSync(path.join(rulesDir, 'behavior.md'), '---\ntest: rule\n---');
+
+    const result = runHook({
+      hook_event_name: 'UserPromptSubmit',
+      cwd: tmpDir,
+      context_window: {
+        context_window_size: 200000,
+        current_usage: {
+          input_tokens: 10000,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0
+        }
+      }
+    });
+
+    expect(result.systemMessage).toContain('Mantra:');
+    expect(result.systemMessage).toContain('5% ctx'); // 10000/200000 = 5%
+    expect(result.systemMessage).toContain('✓');
+    expect(result.hookSpecificOutput.promptCount).toBeGreaterThan(0);
+    expect(result.hookSpecificOutput.rulesLoaded).toBe(true);
+    expect(result.hookSpecificOutput.contextPercentage).toBe(5);
+  });
+
+  it('falls back to prompt count when no context_window data', () => {
     const rulesDir = path.join(tmpDir, '.claude', 'rules');
     fs.mkdirSync(rulesDir, { recursive: true });
     fs.writeFileSync(path.join(rulesDir, 'behavior.md'), '---\ntest: rule\n---');
@@ -82,11 +108,9 @@ describe('mantra status hook', () => {
     });
 
     expect(result.systemMessage).toContain('Mantra:');
-    expect(result.systemMessage).toContain('% ctx');
+    expect(result.systemMessage).toMatch(/#\d+/); // Falls back to #N format
     expect(result.systemMessage).toContain('✓');
-    expect(result.hookSpecificOutput.promptCount).toBeGreaterThan(0);
-    expect(result.hookSpecificOutput.rulesLoaded).toBe(true);
-    expect(result.hookSpecificOutput.estimatedContextFullness).toBeDefined();
+    expect(result.hookSpecificOutput.contextPercentage).toBeNull();
   });
 
   it('increments counter on each UserPromptSubmit', () => {
@@ -135,13 +159,21 @@ describe('mantra status hook', () => {
   it('shows no rules indicator on UserPromptSubmit when rules missing', () => {
     const result = runHook({
       hook_event_name: 'UserPromptSubmit',
-      cwd: tmpDir
+      cwd: tmpDir,
+      context_window: {
+        context_window_size: 200000,
+        current_usage: {
+          input_tokens: 20000,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0
+        }
+      }
     });
 
     expect(result.systemMessage).toContain('no rules');
-    expect(result.systemMessage).toContain('% ctx');
+    expect(result.systemMessage).toContain('10% ctx'); // 20000/200000 = 10%
     expect(result.hookSpecificOutput.rulesLoaded).toBe(false);
-    expect(result.hookSpecificOutput.estimatedContextFullness).toBeDefined();
+    expect(result.hookSpecificOutput.contextPercentage).toBe(10);
   });
 
   it('shows compaction indicator when source is compact', () => {
@@ -239,5 +271,121 @@ describe('mantra status hook', () => {
 
     expect(result.systemMessage).not.toContain('outdated');
     expect(result.hookSpecificOutput.rulesOutdated).toBe(false);
+  });
+
+  it('warns about startup bloat when initial context >35%', () => {
+    const rulesDir = path.join(tmpDir, '.claude', 'rules');
+    fs.mkdirSync(rulesDir, { recursive: true });
+    fs.writeFileSync(path.join(rulesDir, 'behavior.md'), '---\ntest: rule\n---');
+
+    const result = runHook({
+      hook_event_name: 'SessionStart',
+      source: 'startup',
+      cwd: tmpDir,
+      context_window: {
+        context_window_size: 200000,
+        current_usage: {
+          input_tokens: 80000, // 40% - above threshold
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0
+        }
+      }
+    });
+
+    expect(result.systemMessage).toContain('High initial context');
+    expect(result.systemMessage).toContain('40%');
+    expect(result.hookSpecificOutput.startupBloat).toBe(true);
+    expect(result.hookSpecificOutput.contextPercentage).toBe(40);
+  });
+
+  it('does not warn about bloat on resume or compact', () => {
+    const rulesDir = path.join(tmpDir, '.claude', 'rules');
+    fs.mkdirSync(rulesDir, { recursive: true });
+    fs.writeFileSync(path.join(rulesDir, 'behavior.md'), '---\ntest: rule\n---');
+
+    const result = runHook({
+      hook_event_name: 'SessionStart',
+      source: 'resume',
+      cwd: tmpDir,
+      context_window: {
+        context_window_size: 200000,
+        current_usage: {
+          input_tokens: 80000, // 40% - would trigger on startup
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0
+        }
+      }
+    });
+
+    expect(result.systemMessage).not.toContain('High initial context');
+    expect(result.hookSpecificOutput.startupBloat).toBe(false);
+  });
+
+  it('shows context percentage on SessionStart', () => {
+    const rulesDir = path.join(tmpDir, '.claude', 'rules');
+    fs.mkdirSync(rulesDir, { recursive: true });
+    fs.writeFileSync(path.join(rulesDir, 'behavior.md'), '---\ntest: rule\n---');
+
+    const result = runHook({
+      hook_event_name: 'SessionStart',
+      cwd: tmpDir,
+      context_window: {
+        context_window_size: 200000,
+        current_usage: {
+          input_tokens: 20000, // 10%
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0
+        }
+      }
+    });
+
+    expect(result.systemMessage).toContain('@ 10%');
+    expect(result.hookSpecificOutput.contextPercentage).toBe(10);
+  });
+
+  it('warns about drift when context usage >=70%', () => {
+    const rulesDir = path.join(tmpDir, '.claude', 'rules');
+    fs.mkdirSync(rulesDir, { recursive: true });
+    fs.writeFileSync(path.join(rulesDir, 'behavior.md'), '---\ntest: rule\n---');
+
+    const result = runHook({
+      hook_event_name: 'UserPromptSubmit',
+      cwd: tmpDir,
+      context_window: {
+        context_window_size: 200000,
+        current_usage: {
+          input_tokens: 150000, // 75%
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0
+        }
+      }
+    });
+
+    expect(result.systemMessage).toContain('75% ctx');
+    expect(result.systemMessage).toContain('drift');
+    expect(result.hookSpecificOutput.driftWarning).toBe(true);
+  });
+
+  it('does not warn about drift when context usage <70%', () => {
+    const rulesDir = path.join(tmpDir, '.claude', 'rules');
+    fs.mkdirSync(rulesDir, { recursive: true });
+    fs.writeFileSync(path.join(rulesDir, 'behavior.md'), '---\ntest: rule\n---');
+
+    const result = runHook({
+      hook_event_name: 'UserPromptSubmit',
+      cwd: tmpDir,
+      context_window: {
+        context_window_size: 200000,
+        current_usage: {
+          input_tokens: 100000, // 50%
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0
+        }
+      }
+    });
+
+    expect(result.systemMessage).toContain('50% ctx');
+    expect(result.systemMessage).not.toContain('drift');
+    expect(result.hookSpecificOutput.driftWarning).toBe(false);
   });
 });

--- a/mantra/package.json
+++ b/mantra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/mantra",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Behavioral rules for Claude Code sessions - native .claude/rules/ auto-loading",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Use context_window data for accurate context usage percentage instead of rough estimation
- Add startup bloat warning when initial context >35%
- Add drift warning when context usage >=70%
- Fall back to prompt count when context_window unavailable
- Clarify make-rule companion file workflow in README

## Test plan
- [x] Unit tests pass (37 tests)
- [ ] Manual verification of status line output