### PR TITLE
chore - add workflow checkpoints for session management

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memento",
       "source": "./memento",
       "description": "Session persistence - persist context across conversation resets with branch-based session tracking",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     {
       "name": "mantra",

--- a/.claude/sessions/chore-workflow-checkpoints.md
+++ b/.claude/sessions/chore-workflow-checkpoints.md
@@ -1,0 +1,72 @@
+# Session: Implement workflow checkpoints
+
+## Details
+- **Branch**: chore/workflow-checkpoints
+- **Type**: chore
+- **Created**: 2025-12-26
+- **Status**: in-progress
+
+## Goal
+Implement two workflow checkpoints to ensure proper branch/session setup before analysis and implementation:
+1. **Pre-analysis checkpoint**: Before exploring/planning, check if on correct branch
+2. **Pre-implementation checkpoint**: After plan approval, verify session updated
+
+## Problem Statement
+When starting new work, Claude should:
+- Notice if on main branch when user mentions "start a chore/issue"
+- Ask if user wants to create branch + session BEFORE any analysis
+- After plan approval, immediately update session with Approach
+
+Currently this doesn't happen - analysis starts on main with no session tracking.
+
+## Approach
+1. Add PRE-ANALYSIS CHECKPOINT to memento/rules/sessions.md
+2. Add PRE-IMPLEMENTATION CHECKPOINT to memento/rules/sessions.md
+3. Update companion context (memento/context/sessions.md) with detailed explanations
+4. Test the behavior
+
+## Session Log
+
+### 2025-12-26 - Session Started
+- Created branch chore/workflow-checkpoints
+- Identified failure mode: jumped to analysis without branch/session setup
+
+### 2025-12-26 - Implemented Checkpoints (Rules)
+- Added PRE-ANALYSIS CHECKPOINT section to memento/rules/sessions.md
+  - Triggers when user mentions "start/begin/work on" + issue/chore/feature
+  - Checks if on main/master branch
+  - Asks before proceeding with analysis
+- Added PRE-IMPLEMENTATION CHECKPOINT section to memento/rules/sessions.md
+  - Triggers on ExitPlanMode (plan approved)
+  - Verifies branch exists, session exists, updates Approach section
+- Updated memento/context/sessions.md with detailed examples and explanations
+
+### 2025-12-26 - Implemented Hook-Based Checkpoints
+- Researched PostToolUse hook - can match specific tools
+- Created memento/hooks/checkpoint.js to handle checkpoint events
+- Updated memento/hooks/hooks.json with new hooks:
+  - PostToolUse: ExitPlanMode, EnterPlanMode, Task, TodoWrite
+  - PreToolUse: Bash(git commit*)
+- Skipped PR events (too noisy per user feedback)
+
+## Key Decisions
+- **Hook vs Rules**: Rules alone weren't reliable (I failed to follow them). Hooks provide automatic reminders.
+- **PostToolUse for Task**: Capture findings after agent completes, not intent before
+- **Skip PR events**: Commit checkpoints yes, PR events no (too noisy)
+- **Significant agents only**: Only remind for Plan/Explore agents, not quick searches
+
+## Notes
+- Both checkpoints are marked as "BLOCKING REQUIREMENT" in rules
+- Hooks inject additionalContext reminders
+- Pre-analysis uses AskUserQuestion pattern (rule-based)
+- Pre-implementation is automatic (hook-based)
+
+## Files Changed
+- memento/rules/sessions.md (added 2 checkpoint sections)
+- memento/context/sessions.md (added Workflow Checkpoints section)
+- memento/hooks/hooks.json (added PostToolUse, PreToolUse hooks)
+- memento/hooks/checkpoint.js (new - checkpoint handler)
+
+## Next Steps
+1. Run tests to verify no regressions
+2. Commit changes

--- a/memento/.claude-plugin/plugin.json
+++ b/memento/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memento",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Session management for Claude Code - auto-injected via hooks, zero config",
   "author": {
     "name": "David Puglielli"

--- a/memento/context/sessions.md
+++ b/memento/context/sessions.md
@@ -136,6 +136,51 @@ This keeps session maintenance flexible and conversational rather than forcing a
 
 ## Workflow
 
+### Workflow Checkpoints
+
+Two mandatory checkpoints ensure proper session tracking:
+
+#### Pre-Analysis Checkpoint
+
+**When**: User mentions starting new work ("start a chore", "implement feature", "fix bug")
+
+**Check**: Are we on main/master branch?
+
+**If yes**: STOP before any exploration or analysis. Ask:
+> "Should I create a branch and session file before we start?"
+
+**Why**: Prevents analysis work from being lost if conversation resets. Session tracks decisions made during exploration.
+
+**Example**:
+```
+User: "Let's start a chore to fix the config"
+Claude: [Checks branch - on main]
+Claude: "I notice we're on main. Should I create a branch and session file before we start exploring?"
+User: "Yes"
+Claude: [Creates branch, creates session, THEN starts analysis]
+```
+
+#### Pre-Implementation Checkpoint
+
+**When**: ExitPlanMode is used and plan is approved
+
+**Before any code edits**: STOP and verify:
+1. Not on main branch (if so, create branch)
+2. Session file exists (if not, create it)
+3. Update session Approach section with the approved plan
+4. THEN proceed with implementation
+
+**Why**: Ensures the approved plan is captured in the session before implementation begins.
+
+**Example**:
+```
+[Plan approved via ExitPlanMode]
+Claude: [Checks branch - on feature branch ✓]
+Claude: [Checks session - exists ✓]
+Claude: [Updates session Approach section with plan]
+Claude: [THEN creates todo list and starts coding]
+```
+
 ### Starting New Work
 
 **Option 1: Use the start command (recommended)**

--- a/memento/hooks/checkpoint.js
+++ b/memento/hooks/checkpoint.js
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * memento: Checkpoint hook
+ *
+ * Triggers session update reminders on key events:
+ * - PostToolUse: ExitPlanMode, EnterPlanMode, Task, TodoWrite
+ * - PreToolUse: git commit
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// ============================================================================
+// Git Helpers
+// ============================================================================
+
+function getGitRoot(cwd) {
+  try {
+    return execSync('git rev-parse --show-toplevel', {
+      cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+  } catch { return null; }
+}
+
+function getCurrentBranch(cwd) {
+  try {
+    return execSync('git rev-parse --abbrev-ref HEAD', {
+      cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+  } catch { return null; }
+}
+
+// ============================================================================
+// Session Helpers
+// ============================================================================
+
+function getSessionPath(gitRoot, branch) {
+  if (!gitRoot || !branch) return null;
+  const sanitized = branch.replace(/\//g, '-');
+  return path.join(gitRoot, '.claude', 'sessions', `${sanitized}.md`);
+}
+
+function sessionExists(sessionPath) {
+  return sessionPath && fs.existsSync(sessionPath);
+}
+
+// ============================================================================
+// Checkpoint Logic
+// ============================================================================
+
+function buildCheckpointReminder(input) {
+  const toolName = input.tool_name;
+  const hookEvent = input.hook_event_name;
+  const cwd = input.cwd || process.cwd();
+
+  const gitRoot = getGitRoot(cwd);
+  const branch = getCurrentBranch(cwd);
+  const sessionPath = getSessionPath(gitRoot, branch);
+  const hasSession = sessionExists(sessionPath);
+
+  // Skip if on main/master (no session expected)
+  if (branch === 'main' || branch === 'master') {
+    return null;
+  }
+
+  let reminder = null;
+
+  switch (toolName) {
+    case 'ExitPlanMode':
+      // Pre-implementation checkpoint
+      reminder = hasSession
+        ? '📝 **Pre-Implementation Checkpoint**: Update session Approach section with the approved plan before coding.'
+        : '⚠️ **No session file found**. Create session before implementation.';
+      break;
+
+    case 'EnterPlanMode':
+      // Track planning started
+      reminder = '📝 Planning mode started. Session will capture the plan when approved.';
+      break;
+
+    case 'Task':
+      // Check if significant subagent
+      const subagentType = input.tool_input?.subagent_type || '';
+      const significantAgents = ['Plan', 'Explore'];
+      const isSignificant = significantAgents.some(a =>
+        subagentType.toLowerCase().includes(a.toLowerCase())
+      );
+
+      if (isSignificant && hasSession) {
+        reminder = `📝 ${subagentType} agent completed. Consider updating session with findings.`;
+      }
+      break;
+
+    case 'TodoWrite':
+      // Sync reminder
+      if (hasSession) {
+        reminder = '📝 Todos updated. Keep session Next Steps in sync.';
+      }
+      break;
+
+    case 'Bash':
+      // Pre-commit checkpoint (PreToolUse)
+      if (hookEvent === 'PreToolUse') {
+        const command = input.tool_input?.command || '';
+        if (command.includes('git commit')) {
+          reminder = hasSession
+            ? '📝 **Pre-Commit Checkpoint**: Ensure session is updated before committing. Commit session + code together.'
+            : '⚠️ **No session file found**. Consider creating one before commit.';
+        }
+      }
+      break;
+  }
+
+  return reminder;
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+function main() {
+  let inputData = '';
+
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => { inputData += chunk; });
+  process.stdin.on('end', () => {
+    try {
+      const input = JSON.parse(inputData);
+      const reminder = buildCheckpointReminder(input);
+
+      const response = {};
+      if (reminder) {
+        response.additionalContext = `\n${reminder}`;
+      }
+
+      console.log(JSON.stringify(response));
+    } catch (err) {
+      // Silent failure - don't break the hook chain
+      console.log(JSON.stringify({}));
+    }
+  });
+}
+
+main();

--- a/memento/hooks/hooks.json
+++ b/memento/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Session management - auto-create on startup, hand off to skill",
+  "description": "Session management - auto-create on startup, checkpoint on key events",
   "hooks": {
     "SessionStart": [
       {
@@ -18,6 +18,30 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-startup.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "ExitPlanMode|EnterPlanMode|Task|TodoWrite",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/checkpoint.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash(git commit*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/checkpoint.js",
             "timeout": 5
           }
         ]

--- a/memento/package.json
+++ b/memento/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/memento",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Session management for Claude Code - persist context across conversation resets with branch-based session tracking",
   "main": "index.js",
   "scripts": {

--- a/memento/rules/sessions.md
+++ b/memento/rules/sessions.md
@@ -11,6 +11,15 @@ location: {git-root}/.claude/sessions/<branch-sanitized>.md
 auto-create: hook creates on first prompt for feature branches
 one-session: 1 branch = 1 session = 1 issue
 
+## PRE-ANALYSIS CHECKPOINT (BLOCKING REQUIREMENT)
+trigger: user-mentions ("start", "begin", "work on", "implement", "fix", "add") + (issue|chore|feature|bug)
+check: current-branch == main|master
+action: STOP before any analysis/exploration
+ask: "Should I create a branch and session file before we start?"
+if-yes: create-branch → create-session → THEN proceed with analysis
+if-no: proceed (user takes responsibility for branch management)
+never: jump-to-analysis-while-on-main-without-asking
+
 ## STARTING NEW WORK
 command: /memento:start (issue|chore)
 flow: ask-type → get-details → create-branch → create-session → prime-with-context
@@ -23,9 +32,19 @@ on-switch: check-session-exists → find-possible-matches → inject-guidance
 mismatch: detect-session-referencing-branch-with-wrong-filename → offer-rename
 possible-match: score by issue-number (10), description-words (2 each), max 3 results
 
+## PRE-IMPLEMENTATION CHECKPOINT (BLOCKING REQUIREMENT)
+trigger: ExitPlanMode-used (plan approved)
+action: STOP before any code edits or implementation
+must-do:
+  1: verify-branch-exists (not on main)
+  2: verify-session-exists (or create it)
+  3: update-session-Approach-section (with approved plan)
+  4: THEN proceed with implementation
+never: start-coding-without-session-update
+
 ## SESSION POPULATION TRIGGERS
 todos-changed: TodoWrite used → remind update Session Log, Next Steps
-plan-approved: ExitPlanMode used → IMMEDIATELY update Approach section with plan
+plan-approved: ExitPlanMode used → triggers PRE-IMPLEMENTATION CHECKPOINT above
 context-checkpoint: usage > 80% → save state before compaction
 
 ## UPDATE TRIGGERS


### PR DESCRIPTION
## Summary

Adds automatic checkpoint reminders to ensure proper session tracking during development workflow.

### Changes

- Add PRE-ANALYSIS CHECKPOINT rule (ask before analysis when on main)
- Add PRE-IMPLEMENTATION CHECKPOINT rule (verify session after plan approval)
- Add PostToolUse hooks for ExitPlanMode, EnterPlanMode, Task, TodoWrite
- Add PreToolUse hook for git commit detection
- Create checkpoint.js handler for automatic session reminders
- Update context docs with checkpoint examples
- Bump memento to 0.3.1

## Test plan

- [x] Run memento tests (31/31 pass)
- [ ] Verify hooks trigger on ExitPlanMode
- [ ] Verify pre-commit reminder appears