### PR TITLE
chore - add onus init command with type-based formats

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
       "name": "onus",
       "source": "./onus",
       "description": "Work-item automation - fetches issues, generates commits/PRs, syncs progress",
-      "version": "0.2.1"
+      "version": "0.2.2"
     }
   ]
 }

--- a/.claude/sessions/chore-onus-create-config.md
+++ b/.claude/sessions/chore-onus-create-config.md
@@ -1,0 +1,33 @@
+# Session: Create onus init command
+
+## Details
+- **Branch**: chore/onus-create-config
+- **Type**: chore
+- **Created**: 2025-12-26
+- **Status**: complete
+
+## Goal
+Create the `/onus:init` skill command to expose the init.js functionality.
+
+## Session Log
+
+### 2025-12-26 - Session Started
+- Created branch chore/onus-create-config from main
+- Discovered `onus/scripts/init.js` exists but no skill command
+
+### 2025-12-26 - Implementation
+- Created `onus/commands/init.md` skill command
+- Registered command in `onus/.claude-plugin/plugin.json`
+- Updated commitFormat/branchFormat to type-based maps (issue vs chore)
+- Updated `onus/scripts/init.js` DEFAULT_CONFIG
+- Updated `onus/templates/config/config.json.example`
+- Bumped onus version to 0.2.2
+- All 59 tests pass
+
+## Files Changed
+- `onus/commands/init.md` (created)
+- `onus/.claude-plugin/plugin.json` (added init command, version bump)
+- `onus/scripts/init.js` (type-based format maps)
+- `onus/templates/config/config.json.example` (updated formats)
+- `onus/package.json` (version bump)
+- `.claude-plugin/marketplace.json` (version bump)

--- a/onus/.claude-plugin/plugin.json
+++ b/onus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onus",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Work item automation for Claude Code - auto-injected via hooks, zero config",
   "author": {
     "name": "David Puglielli"
@@ -17,6 +17,7 @@
     "jira"
   ],
   "commands": [
+    "./commands/init.md",
     "./commands/fetch.md",
     "./commands/create.md",
     "./commands/update.md",

--- a/onus/commands/init.md
+++ b/onus/commands/init.md
@@ -1,0 +1,91 @@
+---
+description: Initialize onus configuration for a project
+argument-hint: "[--platform github|jira|azure] [--force]"
+---
+
+# Initialize Onus Configuration
+
+Set up `.claude/config.json` with onus configuration for work item tracking.
+
+## Task
+
+Run the init script to create or update the configuration:
+
+```bash
+node /Users/dpuglielli/.claude/plugins/cache/claude-domestique/onus/<version>/scripts/init.js
+```
+
+The script auto-detects GitHub owner/repo from the git remote.
+
+## Platforms
+
+Specify the work item platform (defaults to `github`):
+
+- **github** - GitHub Issues (auto-detected from git remote)
+- **jira** - JIRA (requires manual host/project configuration)
+- **azure** - Azure DevOps (requires manual org/project configuration)
+
+## What It Does
+
+1. Detects GitHub owner/repo from git remote URL
+2. Creates `.claude/config.json` with onus section
+3. Sets default commit/branch formats
+4. Preserves existing config sections (merges, doesn't overwrite)
+
+## Generated Config
+
+```json
+{
+  "onus": {
+    "platform": "github",
+    "github": {
+      "owner": "<detected>",
+      "repo": "<detected>"
+    },
+    "commitFormat": {
+      "issue": "{number} - {verb} {description}",
+      "chore": "chore - {description}"
+    },
+    "branchFormat": {
+      "issue": "issue/{type}-{number}/{slug}",
+      "chore": "chore/{slug}"
+    }
+  }
+}
+```
+
+## Options
+
+- `--force` - Overwrite existing onus config
+- `--platform <name>` - Set work item platform (github, jira, azure)
+
+## After Initialization
+
+For JIRA or Azure DevOps, manually edit `.claude/config.json` to add:
+
+**JIRA:**
+```json
+"jira": {
+  "host": "your-company.atlassian.net",
+  "project": "PROJ"
+}
+```
+
+**Azure DevOps:**
+```json
+"azure": {
+  "org": "your-org",
+  "project": "your-project"
+}
+```
+
+## Troubleshooting
+
+**"Configuration already exists"**
+- Use `--force` to overwrite
+- Or manually edit `.claude/config.json`
+
+**Owner/repo not detected**
+- Ensure you're in a git repository
+- Check that `git remote get-url origin` returns a valid URL
+- For non-GitHub VCS, manually set the github section after init

--- a/onus/package.json
+++ b/onus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/onus",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Work item automation plugin for Claude Code - auto-injected via hooks, zero config",
   "main": "index.js",
   "scripts": {

--- a/onus/scripts/init.js
+++ b/onus/scripts/init.js
@@ -15,8 +15,14 @@ const CONFIG_FILE = '.claude/config.json';
 
 // Default configuration values
 const DEFAULT_CONFIG = {
-  commitFormat: '#{number} - {verb} {description}',
-  branchFormat: 'issue/{type}-{number}/{slug}'
+  commitFormat: {
+    issue: '{number} - {verb} {description}',
+    chore: 'chore - {description}'
+  },
+  branchFormat: {
+    issue: 'issue/{type}-{number}/{slug}',
+    chore: 'chore/{slug}'
+  }
 };
 
 // Supported work item platforms

--- a/onus/templates/config/config.json.example
+++ b/onus/templates/config/config.json.example
@@ -13,8 +13,14 @@
       "org": "your-org",
       "project": "your-project"
     },
-    "commitFormat": "#{number} - {verb} {description}",
-    "branchFormat": "issue/{type}-{number}/{slug}"
+    "commitFormat": {
+      "issue": "{number} - {verb} {description}",
+      "chore": "chore - {description}"
+    },
+    "branchFormat": {
+      "issue": "issue/{type}-{number}/{slug}",
+      "chore": "chore/{slug}"
+    }
   },
   "context": {
     "periodicRefresh": {


### PR DESCRIPTION
## Summary
- Add `/onus:init` skill command to initialize project configuration
- Update commitFormat/branchFormat to use type-based maps (issue vs chore)
- Bump onus version to 0.2.2

## Changes
- `onus/commands/init.md` - New skill command for project config initialization
- `onus/scripts/init.js` - Type-based format maps in DEFAULT_CONFIG
- `onus/templates/config/config.json.example` - Updated format structure
- `onus/.claude-plugin/plugin.json` - Register init command, version bump

## Test plan
- [x] All 59 onus tests pass
- [ ] Run `/onus:init` in a project to verify config creation