### PR TITLE
chore - fix onus init glob pattern and bump versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,19 +8,19 @@
       "name": "memento",
       "source": "./memento",
       "description": "Session persistence - persist context across conversation resets with branch-based session tracking",
-      "version": "0.3.1"
+      "version": "0.3.2"
     },
     {
       "name": "mantra",
       "source": "./mantra",
       "description": "Context refresh - periodic re-injection of behavioral guidance to prevent context drift",
-      "version": "0.3.0"
+      "version": "0.3.1"
     },
     {
       "name": "onus",
       "source": "./onus",
       "description": "Work-item automation - fetches issues, generates commits/PRs, syncs progress",
-      "version": "0.2.3"
+      "version": "0.2.4"
     }
   ]
 }

--- a/mantra/.claude-plugin/plugin.json
+++ b/mantra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mantra",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Behavioral rules for Claude Code sessions - auto-injected via hooks, zero config",
   "author": {
     "name": "David Puglielli"

--- a/mantra/package.json
+++ b/mantra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/mantra",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Behavioral rules for Claude Code sessions - auto-injected via hooks",
   "main": "index.js",
   "scripts": {

--- a/memento/.claude-plugin/plugin.json
+++ b/memento/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memento",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Session management for Claude Code - auto-injected via hooks, zero config",
   "author": {
     "name": "David Puglielli"

--- a/memento/package.json
+++ b/memento/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/memento",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Session management for Claude Code - persist context across conversation resets with branch-based session tracking",
   "main": "index.js",
   "scripts": {

--- a/onus/.claude-plugin/plugin.json
+++ b/onus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onus",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Work item automation for Claude Code - auto-injected via hooks, zero config",
   "author": {
     "name": "David Puglielli"

--- a/onus/commands/init.md
+++ b/onus/commands/init.md
@@ -34,7 +34,7 @@ If a clear pattern emerges (>50% of commits), note it for Step 3.
 Run the init script to create base configuration:
 
 ```bash
-node ~/.claude/plugins/cache/claude-domestique/onus/*/scripts/init.js
+node "$(node -p "require(process.env.HOME + '/.claude/plugins/installed_plugins.json').plugins['onus@claude-domestique'][0].installPath")/scripts/init.js"
 ```
 
 The script auto-detects GitHub owner/repo from the git remote.

--- a/onus/package.json
+++ b/onus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/onus",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Work item automation plugin for Claude Code - auto-injected via hooks, zero config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Fix `/onus:init` command failing when multiple plugin versions are cached
- Use `installed_plugins.json` registry to resolve the exact plugin path instead of glob pattern
- Bump all plugin versions (mantra 0.3.1, memento 0.3.2, onus 0.2.4)

## Test plan

- [ ] Run `/onus:init` in a project with multiple cached onus versions
- [ ] Verify init script runs without "ENOTDIR" error