### PR TITLE
chore - add session validation and periodic reminders

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "memento",
       "source": "./memento",
       "description": "Session persistence - persist context across conversation resets with branch-based session tracking",
-      "version": "0.3.3"
+      "version": "0.3.4"
     },
     {
       "name": "mantra",

--- a/.claude/sessions/chore-rule-trigger-verification.md
+++ b/.claude/sessions/chore-rule-trigger-verification.md
@@ -1,0 +1,77 @@
+# Session: chore/rule-trigger-verification
+
+**Branch:** `chore/rule-trigger-verification`
+**Type:** Chore
+**Status:** complete
+
+## Goal
+
+Solve the problem where rules in context aren't being actively consulted at trigger points. Rules define triggers, but Claude doesn't reliably execute verification at those moments.
+
+## Problem Statement
+
+From user analysis:
+1. Context loss from compaction: summaries don't explicitly note "session file still has placeholders"
+2. No verification step: never read session file to check its state
+3. Rule awareness vs. rule application: rules in context, but not actively consulted at trigger points
+4. No thinking block verification at trigger moments
+
+Root cause: Having rules in context isn't enough - need to actively consult them at the specified moments.
+
+## Approach
+
+MVP approach with two components:
+
+1. **Session file validation before git commit** (checkpoint.js)
+   - Read session file content before git commit
+   - Check for placeholder text patterns
+   - Inject specific, actionable warning if placeholders found
+
+2. **Periodic session update reminder** (session-startup.js)
+   - Every 5 prompts, inject a more prominent reminder
+   - Asks: "Has anything happened worth recording?"
+   - Prompts to capture key decisions, requirements, design changes, blockers
+
+Key insight: UserPromptSubmit hooks can't see user prompt text, but PreToolUse hooks CAN see the exact tool being invoked. We use this for commit validation.
+
+## Session Log
+
+- Created branch and session file
+- Reviewed existing rule-design guide (just added)
+- Reviewed sessions.md and git.md rules - they have proper structure but no enforcement
+- Explored hook system: learned UserPromptSubmit can't see prompt text, only tool usage
+- Explored existing MANDATORY-REREAD patterns and precedence reminders
+- Designed state-aware validation approach using PreToolUse hooks
+- Implemented `validateSessionFile()` function in checkpoint.js
+- Updated git commit case to check for placeholders and inject specific warnings
+- Added comprehensive tests for validation functionality
+- Added periodic session update reminder (every 5 prompts) to session-startup.js
+- All tests pass (42 in memento)
+- Bumped memento version 0.3.3 → 0.3.4
+
+## Files Changed
+
+- `memento/hooks/checkpoint.js` - Added validateSessionFile() function, state-aware git commit warnings, exports for testing
+- `memento/hooks/__tests__/checkpoint.test.js` - New test file for checkpoint validation (10 tests)
+- `memento/hooks/session-startup.js` - Added periodic session update reminder every 5 prompts
+- `memento/package.json` - Version 0.3.4
+- `memento/.claude-plugin/plugin.json` - Version 0.3.4
+- `.claude-plugin/marketplace.json` - memento version 0.3.4
+
+## Next Steps
+
+- [x] Add validateSessionFile() function to checkpoint.js
+- [x] Update git commit case to use validation
+- [x] Add tests for session validation
+- [x] Run tests to verify no regressions
+- [x] Add periodic session update reminder to UserPromptSubmit
+- [x] Bump memento patch version
+- [ ] Commit changes
+- [ ] Create PR
+
+## Future Enhancements (not in this MVP)
+
+- Add detection for `gh pr create` commands
+- Add branch validation (warn if on main)
+- Create gatekeeper.js in onus for git-specific enforcement
+- Strengthen precedence reminder with action-oriented wording

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,10 @@
   "statusLine": {
     "type": "command",
     "command": ".claude/statusline.js"
+  },
+  "enabledPlugins": {
+    "mantra@claude-domestique": true,
+    "memento@claude-domestique": true,
+    "onus@claude-domestique": true
   }
 }

--- a/.claude/statusline.js
+++ b/.claude/statusline.js
@@ -1,56 +1,37 @@
 #!/usr/bin/env node
 /**
- * mantra statusline script
+ * Project statusline script
  *
- * Outputs a status line showing rules, context, model, and cost.
+ * Outputs a status line showing git branch, context utilization, model, and cost.
  * Receives JSON data from Claude Code via stdin (Status event).
  *
- * Output format: "📍 Mantra: N rules @ X% | Model | $0.00"
+ * Context utilization thresholds:
+ *   0-69%:  Green  - Good, rules are being followed
+ *   70-79%: Yellow - Warning, consider wrapping up current task
+ *   80-89%: Orange - Strong warning, update session file, consider /compact
+ *   90%+:  Red    - Critical, save context NOW, start fresh conversation
+ *
+ * High utilization risk: Claude may disregard project rules and drift to base training.
  */
 
 const fs = require('fs');
 const path = require('path');
+const { execSync } = require('child_process');
 
-const DRIFT_WARNING_THRESHOLD = 70;
+// Context utilization thresholds
+const THRESHOLD_WARNING = 70;        // Yellow
+const THRESHOLD_STRONG_WARNING = 80; // Orange
+const THRESHOLD_CRITICAL = 90;       // Red
 
-/**
- * Format cost as currency string
- * @param {number} costUsd - Cost in USD
- * @returns {string} Formatted cost (e.g., "$0.12" or "$1.23")
- */
-function formatCost(costUsd) {
-  if (costUsd === null || costUsd === undefined) {
-    return null;
-  }
-  if (costUsd < 0.01) {
-    return '$0.00';
-  }
-  if (costUsd < 1) {
-    return `$${costUsd.toFixed(2)}`;
-  }
-  return `$${costUsd.toFixed(2)}`;
-}
-
-/**
- * Get short model name
- * @param {object} model - Model info from Claude Code
- * @returns {string|null} Short model name
- */
-function getModelName(model) {
-  if (!model) return null;
-  // Prefer display_name, fall back to extracting from id
-  if (model.display_name) {
-    return model.display_name;
-  }
-  if (model.id) {
-    // Extract model name from id like "claude-opus-4-1" -> "Opus"
-    const match = model.id.match(/claude-(\w+)-/i);
-    if (match) {
-      return match[1].charAt(0).toUpperCase() + match[1].slice(1);
-    }
-  }
-  return null;
-}
+// ANSI color codes
+const COLORS = {
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  orange: '\x1b[38;5;208m',
+  red: '\x1b[31m',
+  reset: '\x1b[0m',
+  dim: '\x1b[2m',
+};
 
 /**
  * Get current context tokens from context_window data
@@ -108,43 +89,149 @@ function getRulesCount(cwd) {
 }
 
 /**
+ * Get current git branch name
+ */
+function getGitBranch(cwd) {
+  try {
+    const branch = execSync('git branch --show-current', {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return branch || null;
+  } catch (e) {
+    return null;
+  }
+}
+
+/**
+ * Extract work item ID from branch name
+ * Matches patterns like: 120677-description, issue/feature-120677/desc
+ */
+function extractWorkItemId(branch) {
+  if (!branch) return null;
+
+  // Match 5-6 digit numbers (Azure DevOps work item IDs)
+  const match = branch.match(/(\d{5,6})/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Check if session file exists for current branch
+ */
+function hasSessionFile(cwd, branch) {
+  if (!branch) return false;
+
+  // Sanitize branch name for filename (replace / with -)
+  const sanitized = branch.replace(/\//g, '-');
+  const sessionPath = path.join(cwd, '.claude', 'sessions', `${sanitized}.md`);
+
+  return fs.existsSync(sessionPath);
+}
+
+/**
+ * Get color and status for context utilization percentage
+ */
+function getContextStatus(percent) {
+  if (percent === null) {
+    return { color: COLORS.dim, status: '', advice: '' };
+  }
+
+  if (percent >= THRESHOLD_CRITICAL) {
+    return {
+      color: COLORS.red,
+      status: '🔴',
+      advice: 'CRITICAL: Save to session, start new conversation',
+    };
+  }
+  if (percent >= THRESHOLD_STRONG_WARNING) {
+    return {
+      color: COLORS.orange,
+      status: '🟠',
+      advice: 'Update session file NOW, consider /compact',
+    };
+  }
+  if (percent >= THRESHOLD_WARNING) {
+    return {
+      color: COLORS.yellow,
+      status: '🟡',
+      advice: 'Consider wrapping up current task',
+    };
+  }
+  return {
+    color: COLORS.green,
+    status: '🟢',
+    advice: 'Project rules active, context healthy',
+  };
+}
+
+/**
+ * Get session filename for branch
+ */
+function getSessionFileName(branch) {
+  if (!branch) return null;
+  // Sanitize branch name for filename (replace / with -)
+  return branch.replace(/\//g, '-') + '.md';
+}
+
+/**
  * Generate status line
  */
 function generateStatusLine(data) {
   const cwd = data.cwd || data.workspace?.current_dir || process.cwd();
   const rulesCount = getRulesCount(cwd);
   const contextPercent = calculateContextPercentage(data.context_window);
-  const modelName = getModelName(data.model);
-  const cost = formatCost(data.cost?.total_cost_usd);
-
-  const contextPart = contextPercent !== null ? `${contextPercent}%` : '?';
-
-  let driftWarning = '';
-  if (contextPercent !== null && contextPercent >= DRIFT_WARNING_THRESHOLD) {
-    driftWarning = ' \u26a0\ufe0f';
-  }
+  const branch = getGitBranch(cwd);
+  const contextStatus = getContextStatus(contextPercent);
+  const workItemId = extractWorkItemId(branch);
+  const sessionExists = hasSessionFile(cwd, branch);
+  const sessionFileName = getSessionFileName(branch);
 
   // Build status parts
   const parts = [];
 
-  // Rules and context
+  // Branch name
+  if (branch) {
+    parts.push(`${COLORS.dim}${branch}${COLORS.reset}`);
+  }
+
+  // Work item ID or "chore"
+  if (workItemId) {
+    parts.push(`#${workItemId}`);
+  } else if (branch) {
+    parts.push('chore');
+  }
+
+  // Session file name (colored based on existence)
+  if (sessionFileName) {
+    const sessionPart = sessionExists
+      ? `${COLORS.green}${sessionFileName}${COLORS.reset}`
+      : `${COLORS.yellow}${sessionFileName}?${COLORS.reset}`;
+    parts.push(sessionPart);
+  }
+
+  // Context utilization with color-coded status
+  const contextPart = contextPercent !== null ? `${contextPercent}%` : '?';
+  const coloredContext = `${contextStatus.color}${contextPart}${COLORS.reset}`;
+
   if (rulesCount > 0) {
-    parts.push(`${rulesCount} rules @ ${contextPart}${driftWarning}`);
+    parts.push(`${contextStatus.status} ${coloredContext}`);
   } else {
-    parts.push(`${contextPart}${driftWarning} (no rules)`);
+    parts.push(`${contextStatus.status} ${coloredContext} (no rules)`);
   }
 
-  // Model name
-  if (modelName) {
-    parts.push(modelName);
+  // Add advice if context is high
+  let adviceLine = '';
+  if (contextStatus.advice) {
+    adviceLine = `\n  ${contextStatus.color}↳ ${contextStatus.advice}${COLORS.reset}`;
   }
 
-  // Cost
-  if (cost) {
-    parts.push(cost);
+  // Add session warning if missing
+  if (!sessionExists && branch && !branch.startsWith('main')) {
+    adviceLine += `\n  ${COLORS.yellow}↳ No session file - run /memento:session to create${COLORS.reset}`;
   }
 
-  return `\ud83d\udccd Mantra: ${parts.join(' | ')}`;
+  return `${parts.join(' | ')}${adviceLine}`;
 }
 
 // Main
@@ -156,6 +243,6 @@ process.stdin.on('end', () => {
     const data = JSON.parse(input);
     console.log(generateStatusLine(data));
   } catch (e) {
-    console.log('\ud83d\udccd Mantra: ?');
+    console.log('? | ?');
   }
 });

--- a/memento/.claude-plugin/plugin.json
+++ b/memento/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memento",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Session management for Claude Code - auto-injected via hooks, zero config",
   "author": {
     "name": "David Puglielli"

--- a/memento/hooks/__tests__/checkpoint.test.js
+++ b/memento/hooks/__tests__/checkpoint.test.js
@@ -1,0 +1,217 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Mock child_process before requiring the module
+const mockExecSync = jest.fn();
+jest.mock('child_process', () => ({
+  execSync: mockExecSync
+}));
+
+describe('checkpoint.js', () => {
+  let hook;
+  let tmpDir;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'checkpoint-test-'));
+    jest.resetModules();
+    jest.doMock('child_process', () => ({
+      execSync: mockExecSync
+    }));
+    hook = require('../checkpoint.js');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('validateSessionFile', () => {
+    it('returns missing when file does not exist', () => {
+      const result = hook.validateSessionFile('/nonexistent/path.md');
+      expect(result).toEqual({ valid: false, issue: 'missing' });
+    });
+
+    it('returns missing when path is null', () => {
+      const result = hook.validateSessionFile(null);
+      expect(result).toEqual({ valid: false, issue: 'missing' });
+    });
+
+    it('detects [Describe the objective placeholder', () => {
+      const sessionPath = path.join(tmpDir, 'session.md');
+      fs.writeFileSync(sessionPath, `# Session
+
+## Goal
+[Describe the objective here]
+
+## Next Steps
+1. First task
+`);
+      const result = hook.validateSessionFile(sessionPath);
+      expect(result.valid).toBe(false);
+      expect(result.issue).toBe('placeholders');
+      expect(result.pattern).toContain('[Describe the objective');
+    });
+
+    it('detects [First task placeholder', () => {
+      const sessionPath = path.join(tmpDir, 'session.md');
+      fs.writeFileSync(sessionPath, `# Session
+
+## Goal
+Implement feature X
+
+## Next Steps
+1. [First task here]
+2. Second task
+`);
+      const result = hook.validateSessionFile(sessionPath);
+      expect(result.valid).toBe(false);
+      expect(result.issue).toBe('placeholders');
+      expect(result.pattern).toContain('[First task');
+    });
+
+    it('detects Goal followed by bracket placeholder', () => {
+      const sessionPath = path.join(tmpDir, 'session.md');
+      fs.writeFileSync(sessionPath, `# Session
+
+## Goal
+
+[Something here]
+
+## Next Steps
+1. Do the thing
+`);
+      const result = hook.validateSessionFile(sessionPath);
+      expect(result.valid).toBe(false);
+      expect(result.issue).toBe('placeholders');
+    });
+
+    it('returns valid for properly filled session', () => {
+      const sessionPath = path.join(tmpDir, 'session.md');
+      fs.writeFileSync(sessionPath, `# Session: chore/my-feature
+
+**Branch:** chore/my-feature
+**Type:** Chore
+**Status:** in-progress
+
+## Goal
+
+Implement the session validation feature.
+
+## Session Log
+
+- Started work on the feature
+- Added validateSessionFile function
+
+## Next Steps
+
+1. Add tests
+2. Run test suite
+3. Create PR
+`);
+      const result = hook.validateSessionFile(sessionPath);
+      expect(result).toEqual({ valid: true });
+    });
+
+    it('detects [Record key architectural placeholder', () => {
+      const sessionPath = path.join(tmpDir, 'session.md');
+      fs.writeFileSync(sessionPath, `# Session
+
+## Key Decisions
+[Record key architectural decisions here]
+
+## Goal
+Do something
+`);
+      const result = hook.validateSessionFile(sessionPath);
+      expect(result.valid).toBe(false);
+      expect(result.pattern).toContain('[Record key architectural');
+    });
+  });
+
+  describe('buildCheckpointReminder for git commit', () => {
+    beforeEach(() => {
+      // Setup git mocks
+      mockExecSync.mockImplementation((cmd) => {
+        if (cmd.includes('rev-parse --show-toplevel')) return tmpDir + '\n';
+        if (cmd.includes('rev-parse --abbrev-ref')) return 'feature/test\n';
+        throw new Error('Unknown command');
+      });
+    });
+
+    it('warns when no session file exists', () => {
+      const input = {
+        tool_name: 'Bash',
+        hook_event_name: 'PreToolUse',
+        tool_input: { command: 'git commit -m "test"' },
+        cwd: tmpDir
+      };
+
+      const result = hook.buildCheckpointReminder(input);
+      expect(result).toContain('STOP');
+      expect(result).toContain('No session file found');
+    });
+
+    it('warns when session has placeholders', () => {
+      // Create session with placeholders
+      const sessionsDir = path.join(tmpDir, '.claude', 'sessions');
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(sessionsDir, 'feature-test.md'),
+        '## Goal\n[Describe the objective here]'
+      );
+
+      const input = {
+        tool_name: 'Bash',
+        hook_event_name: 'PreToolUse',
+        tool_input: { command: 'git commit -m "test"' },
+        cwd: tmpDir
+      };
+
+      const result = hook.buildCheckpointReminder(input);
+      expect(result).toContain('STOP');
+      expect(result).toContain('placeholder text');
+      expect(result).toContain('[Describe the objective');
+    });
+
+    it('provides normal reminder when session is valid', () => {
+      // Create properly filled session
+      const sessionsDir = path.join(tmpDir, '.claude', 'sessions');
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(sessionsDir, 'feature-test.md'),
+        '## Goal\nImplement feature X\n\n## Next Steps\n1. First step'
+      );
+
+      const input = {
+        tool_name: 'Bash',
+        hook_event_name: 'PreToolUse',
+        tool_input: { command: 'git commit -m "test"' },
+        cwd: tmpDir
+      };
+
+      const result = hook.buildCheckpointReminder(input);
+      expect(result).toContain('Pre-Commit');
+      expect(result).toContain('Session exists');
+      expect(result).not.toContain('STOP');
+    });
+
+    it('returns null when on main branch', () => {
+      mockExecSync.mockImplementation((cmd) => {
+        if (cmd.includes('rev-parse --show-toplevel')) return tmpDir + '\n';
+        if (cmd.includes('rev-parse --abbrev-ref')) return 'main\n';
+        throw new Error('Unknown command');
+      });
+
+      const input = {
+        tool_name: 'Bash',
+        hook_event_name: 'PreToolUse',
+        tool_input: { command: 'git commit -m "test"' },
+        cwd: tmpDir
+      };
+
+      const result = hook.buildCheckpointReminder(input);
+      expect(result).toBe(null);
+    });
+  });
+});

--- a/memento/hooks/session-startup.js
+++ b/memento/hooks/session-startup.js
@@ -370,7 +370,14 @@ function onUserPromptSubmit(input, base) {
   if (triggers.length > 0) {
     context += buildTriggerContext(triggers, sessionPath);
   } else {
-    context += '\nAfter responding: assess if work warrants session update (milestones, decisions, blockers).';
+    // Periodic reminder every 5 prompts to assess session state
+    const promptCount = base.promptCount || 0;
+    const SESSION_REMINDER_INTERVAL = 5;
+    if (promptCount > 0 && promptCount % SESSION_REMINDER_INTERVAL === 0) {
+      context += '\n\n📝 **Session Check**: Has anything happened worth recording? Key decisions, requirements, design changes, or blockers should be captured in the session file.';
+    } else {
+      context += '\nAfter responding: assess if work warrants session update (milestones, decisions, blockers).';
+    }
   }
 
   return {

--- a/memento/package.json
+++ b/memento/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/memento",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Session management for Claude Code - persist context across conversation resets with branch-based session tracking",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Add `validateSessionFile()` to checkpoint.js - checks for placeholder text before git commit and injects specific warnings
- Add periodic session update reminder every 5 prompts in session-startup.js
- Add comprehensive tests for session validation (10 new tests)
- Redesign statusline with context utilization indicators and session file status
- Add enabledPlugins to settings.json
- Bump memento version 0.3.3 → 0.3.4

## Problem Solved

Rules in context weren't being actively consulted at trigger points. Claude would have rules like "update session before commit" but not verify actual session file state.

## Solution

1. **State validation**: Before git commit, read session file and check for placeholder patterns
2. **Periodic reminders**: Every 5 prompts, prompt Claude to consider if anything worth recording happened
3. **Statusline**: Show context utilization with color-coded warnings and session file existence

## Test plan

- [x] All memento tests pass (42 tests)
- [x] validateSessionFile correctly detects placeholder patterns
- [x] Git commit warning includes specific placeholder text when found
- [ ] Manual test: commit with placeholder session file shows STOP warning