### PR TITLE
#117 - add phase 2 skills and fix onus hook crash

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,13 +14,13 @@
       "name": "mantra",
       "source": "./mantra",
       "description": "Context refresh - periodic re-injection of behavioral guidance to prevent context drift",
-      "version": "0.3.2"
+      "version": "0.4.0"
     },
     {
       "name": "onus",
       "source": "./onus",
       "description": "Work-item automation - fetches issues, generates commits/PRs, syncs progress",
-      "version": "0.2.7"
+      "version": "0.3.0"
     }
   ]
 }

--- a/.claude/sessions/issue-feature-117-phase-2-skills.md
+++ b/.claude/sessions/issue-feature-117-phase-2-skills.md
@@ -1,0 +1,94 @@
+# Session: Extract Phase 2 skills
+
+## Details
+- **Issue**: #117
+- **Branch**: issue/feature-117/phase-2-skills
+- **Type**: feature
+- **Created**: 2026-01-01
+- **Status**: complete
+
+## Objective
+Extract Phase 2 skills from rules/context files. Follow-up to #113 (Phase 1).
+
+## Acceptance Criteria
+- [x] Each skill has `commands/*.md` for explicit invocation
+- [x] Skills reference existing rules/context rather than duplicating
+- [x] Plugin versions bumped appropriately
+- [x] Tests pass
+
+## Proposed Skills
+
+### mantra plugin
+1. `/mantra:assess` - Structured critical assessment (from behavior.md)
+2. `/mantra:troubleshoot` - Evidence-based debugging (from behavior.md)
+
+### onus plugin
+3. `/onus:validate-criteria` - Acceptance criteria checker (from work-items.md)
+4. `/onus:status` - Work item dashboard
+
+## Technical Approach
+- Read source behavior.md and work-items.md for skill content
+- Create command files referencing rules rather than duplicating
+- Each skill includes: Task, Output Format, Example, When to Use
+- Updated rules to reference skills with `skill:` field
+- Streamlined rules to reduce redundancy (detailed content now in skills)
+
+## Session Log
+
+### 2026-01-01 - Session Started
+- Created branch and session file from issue #117
+- Prior work: Completed #115 (session complete before commit) and closed #113 (Phase 1 skills)
+- Created this issue (#117) as follow-up for Phase 2 skills
+
+### 2026-01-01 - Bug Fix (statusline)
+- Fixed statusline.js showing "chore" instead of issue number
+- Root cause: regex `\d{5,6}` only matched 5-6 digit numbers (Azure DevOps)
+- Fix: Changed to `\d{1,6}` to match GitHub issue numbers (1-6 digits)
+
+### 2026-01-01 - Bug Fix (commitFormat)
+- Fixed onus hook crash: `TypeError: cfg.commitFormat.replace is not a function`
+- Root cause: Project config has `commitFormat` as object `{issue:..., chore:...}` but code expected string
+- Fix: Added `getCommitFormat()` helper to handle both string and object formats
+- Bumped onus version 0.2.7 → 0.2.8
+
+### 2026-01-01 - Phase 2 Skills Complete
+- Created 4 skills:
+  - `/mantra:assess` - Structured critical assessment
+  - `/mantra:troubleshoot` - Evidence-based debugging
+  - `/onus:validate-criteria` - Acceptance criteria checker
+  - `/onus:status` - Work item dashboard
+- Bumped mantra 0.3.2 → 0.4.0, onus 0.2.8 → 0.3.0
+- Updated rules to reference skills, removed redundant content
+- Updated READMEs with new commands
+- All tests pass (mantra 25, memento 42, onus 65)
+
+## Key Decisions
+- Fixed statusline bug as part of this issue (discovered while working on it)
+- Fixed onus commitFormat bug (blocking issue, prevents plugin from loading)
+- Rules reference skills via `skill:` field to reduce duplication
+- Streamlined rules to reduce initial context token usage
+
+## Learnings
+- statusline.js was originally written for Azure DevOps (5-6 digit IDs)
+- GitHub issues use smaller numbers, need broader pattern
+- Skills can contain detailed procedural content; rules just need trigger/action/skill-reference
+
+## Files Changed
+- .claude/statusline.js - Fixed extractWorkItemId regex
+- onus/hooks/work-item.js - Added getCommitFormat() helper
+- onus/hooks/__tests__/work-item.test.js - Added tests for getCommitFormat
+- mantra/commands/assess.md - New skill
+- mantra/commands/troubleshoot.md - New skill
+- onus/commands/validate-criteria.md - New skill
+- onus/commands/status.md - New skill
+- mantra/rules/behavior.md - Streamlined, added skill references
+- onus/rules/work-items.md - Streamlined, added skill references
+- mantra/README.md - Added new commands
+- onus/README.md - Added new commands
+- mantra/package.json, mantra/.claude-plugin/plugin.json - Version 0.4.0
+- onus/package.json, onus/.claude-plugin/plugin.json - Version 0.3.0
+- .claude-plugin/marketplace.json - Updated versions
+
+## Next Steps
+1. Commit all changes
+2. Create PR

--- a/.claude/statusline.js
+++ b/.claude/statusline.js
@@ -106,13 +106,13 @@ function getGitBranch(cwd) {
 
 /**
  * Extract work item ID from branch name
- * Matches patterns like: 120677-description, issue/feature-120677/desc
+ * Matches patterns like: 117, 120677-description, issue/feature-120677/desc
  */
 function extractWorkItemId(branch) {
   if (!branch) return null;
 
-  // Match 5-6 digit numbers (Azure DevOps work item IDs)
-  const match = branch.match(/(\d{5,6})/);
+  // Match 1-6 digit numbers (GitHub issues and Azure DevOps work item IDs)
+  const match = branch.match(/(\d{1,6})/);
   return match ? match[1] : null;
 }
 

--- a/mantra/.claude-plugin/plugin.json
+++ b/mantra/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mantra",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Behavioral rules for Claude Code sessions - auto-injected via hooks, zero config",
   "author": {
     "name": "David Puglielli"

--- a/mantra/README.md
+++ b/mantra/README.md
@@ -92,6 +92,8 @@ The status line is a CLI feature. In VS Code, use Claude Code from the integrate
 | Command | Description |
 |---------|-------------|
 | `/mantra:make-rule` | Create compact frontmatter rule from verbose markdown |
+| `/mantra:assess` | Structured critical assessment (correctness, architecture, alternatives, risks) |
+| `/mantra:troubleshoot` | Evidence-based debugging (requires 3+ documented examples) |
 
 ### Creating Custom Rules
 

--- a/mantra/commands/assess.md
+++ b/mantra/commands/assess.md
@@ -1,0 +1,110 @@
+---
+description: Perform structured critical assessment of a proposal or approach
+argument-hint: [proposal or context]
+---
+
+# Critical Assessment
+
+Perform a structured evaluation of a proposal, approach, or solution before implementation.
+
+## Task
+
+**IMPORTANT: This skill implements the CRITICAL ASSESSMENT rule from behavior.md**
+
+When the user presents a proposal, solution, or asks for agreement on an approach, you MUST assess before agreeing.
+
+### Assessment Framework
+
+Evaluate these dimensions in order:
+
+1. **Correctness**
+   - Does this solve the stated problem?
+   - Are there logical errors or misconceptions?
+   - Are the assumptions valid?
+
+2. **Architecture**
+   - Does this fit the existing codebase patterns?
+   - Are there separation of concerns issues?
+   - Will this scale appropriately?
+
+3. **Alternatives**
+   - What other approaches could work?
+   - Why might they be better or worse?
+   - Are we missing a simpler solution?
+
+4. **Risks**
+   - What could go wrong?
+   - What edge cases aren't handled?
+   - Security, performance, maintainability concerns?
+
+### Assessment Stance
+
+- **Skeptical by default**: Find problems, not agreement
+- **Peer, not subordinate**: Challenge politely but directly
+- **Honest over agreeable**: Truth serves better than validation
+
+### Output Format
+
+Structure your response as:
+
+```
+## Assessment: [proposal summary]
+
+### Correctness
+[findings]
+
+### Architecture
+[findings]
+
+### Alternatives
+[findings]
+
+### Risks
+[findings]
+
+### Recommendation
+[approve/revise/reject with reasoning]
+```
+
+## Example
+
+```
+User: /mantra:assess I think we should add a caching layer using Redis for all API responses
+
+Claude: ## Assessment: Add Redis caching for all API responses
+
+### Correctness
+The goal of improving response times is valid, but "all API responses" is too broad. Some endpoints (user profile, real-time data) shouldn't be cached.
+
+### Architecture
+Adding Redis creates a new infrastructure dependency. Current architecture uses in-memory caching for specific endpoints. Mixing approaches may create inconsistency.
+
+### Alternatives
+1. **Expand existing in-memory caching** - simpler, no new deps
+2. **CDN edge caching** - better for static/semi-static responses
+3. **Selective Redis** - only for specific expensive queries
+
+### Risks
+- Cache invalidation complexity
+- Redis availability becomes critical path
+- Memory costs for unused cached data
+- Cold start problems after Redis restart
+
+### Recommendation
+**Revise**: Start with selective caching for identified slow endpoints. Measure before adding infrastructure complexity. Consider: which specific endpoints are slow? What's the current p99 latency?
+```
+
+## When to Use
+
+Invoke this skill when:
+- You're about to agree with a proposal without analysis
+- The user asks "what do you think of this approach?"
+- Before implementing a non-trivial change
+- When the user presents multiple options
+
+## Anti-Patterns
+
+- Saying "that sounds good" without analysis
+- Agreeing to avoid conflict
+- Skipping assessment because the user seems confident
+- Rubber-stamping decisions from authority figures

--- a/mantra/commands/troubleshoot.md
+++ b/mantra/commands/troubleshoot.md
@@ -1,0 +1,155 @@
+---
+description: Evidence-based debugging workflow for errors and bugs
+argument-hint: [error message or bug description]
+---
+
+# Troubleshoot
+
+Perform evidence-based debugging using documented examples rather than guessing.
+
+## Task
+
+**IMPORTANT: This skill implements the TROUBLESHOOTING & DEBUGGING rule from behavior.md**
+
+When the user reports an error, bug, or unexpected behavior, you MUST find documented evidence before proposing fixes. No guessing.
+
+### Evidence-Based Workflow
+
+1. **Gather Context**
+   - Get full error message and stack trace
+   - Identify version numbers (runtime, libraries, tools)
+   - Understand what the user was trying to do
+
+2. **Research First**
+   Use these sources in order:
+   - **GitHub Issues**: Search the project's issue tracker
+   - **Web Search**: Find real documented cases
+   - **Official Docs**: Check changelogs, known issues, migration guides
+
+3. **Cross-Reference Requirement**
+   - Find minimum 3 documented examples of the same or similar error
+   - Sources must be authoritative (issue trackers, release notes, official docs)
+   - Do NOT rely on a single Stack Overflow answer
+
+4. **Pattern Matching**
+   Only after finding documented evidence:
+   - Identify common causes across examples
+   - Note what solutions worked in each case
+   - Determine if user's context matches
+
+5. **Propose Solution**
+   - Reference the documented examples
+   - Explain why this solution applies to user's case
+   - Provide verification steps
+
+### What NOT to Do
+
+- Jump to "common solutions" from training data
+- Pattern-match without verification
+- Shotgun debugging (try random fixes)
+- Fill knowledge gaps with speculation
+- Propose fixes without citing sources
+
+### Output Format
+
+```
+## Troubleshooting: [error summary]
+
+### Context Gathered
+- Error: [full message]
+- Environment: [versions, platform]
+- Action: [what user was doing]
+
+### Research Findings
+
+**Source 1**: [link or reference]
+- Cause: [identified cause]
+- Solution: [what worked]
+
+**Source 2**: [link or reference]
+- Cause: [identified cause]
+- Solution: [what worked]
+
+**Source 3**: [link or reference]
+- Cause: [identified cause]
+- Solution: [what worked]
+
+### Analysis
+[Common patterns across sources, applicability to user's case]
+
+### Recommended Fix
+[Solution with steps]
+
+### Verification
+[How to confirm the fix worked]
+```
+
+## Example
+
+```
+User: /mantra:troubleshoot TypeError: Cannot read properties of undefined (reading 'map')
+
+Claude: ## Troubleshooting: TypeError on .map()
+
+### Context Gathered
+Let me get more details:
+- Where does this error occur? (file:line)
+- What data are you mapping over?
+- Did this work before? What changed recently?
+
+[After user provides context]
+
+### Research Findings
+
+**Source 1**: React GitHub Issue #14920
+- Cause: API response returning undefined before data loads
+- Solution: Add loading state or optional chaining
+
+**Source 2**: Stack Overflow - verified answer with 200+ votes
+- Cause: Component renders before async data arrives
+- Solution: Initialize state with empty array, not undefined
+
+**Source 3**: React Docs - Conditional Rendering
+- Cause: Race condition between render and data fetch
+- Solution: Guard clause or early return when data unavailable
+
+### Analysis
+All three sources point to the same root cause: trying to call .map() on data that hasn't loaded yet. Your fetch likely returns undefined on error or hasn't completed.
+
+### Recommended Fix
+```javascript
+// Before
+{items.map(item => ...)}
+
+// After - Option 1: Optional chaining
+{items?.map(item => ...) ?? null}
+
+// After - Option 2: Guard clause
+{items && items.length > 0 && items.map(item => ...)}
+
+// After - Option 3: Loading state (preferred)
+if (!items) return <Loading />;
+return items.map(item => ...);
+```
+
+### Verification
+- Error should not occur when component first renders
+- Check Network tab to confirm API response shape
+- Add console.log before .map() to verify data structure
+```
+
+## When to Use
+
+Invoke this skill when:
+- User reports an error message
+- Something "stopped working"
+- Unexpected behavior occurs
+- User asks "why is this happening?"
+
+## When Stuck
+
+If you can't find 3 documented examples:
+- Ask user for more context (exact error, reproduction steps)
+- Search with different keywords
+- Check if this is a new/unreported issue
+- Do NOT guess - say "I couldn't find documented cases for this specific issue"

--- a/mantra/package.json
+++ b/mantra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/mantra",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Behavioral rules for Claude Code sessions - auto-injected via hooks",
   "main": "index.js",
   "scripts": {

--- a/mantra/rules/behavior.md
+++ b/mantra/rules/behavior.md
@@ -12,12 +12,10 @@ MANDATORY-REREAD: before-implementation-proposal-response (use-thinking-block)
 ## CRITICAL ASSESSMENT (BLOCKING REQUIREMENT)
 trigger: user proposes solution, asks for agreement, presents approach
 priority: BLOCKING
-action: You MUST assess before agreeing. STOP and evaluate first.
-assess-first: correctness, architecture, alternatives, risks (required-before-any-agreement)
-stance: skeptical-default, find-problems-not-agreement, peer-not-subordinate
-never: eager-agreement, sycophantic-tone, yes-without-analysis
-verify: "Assessing: correctness, architecture, alternatives, risks"
-consequence: Eager agreement leads to flawed implementations and missed issues
+action: assess-before-agreeing (correctness, architecture, alternatives, risks)
+stance: skeptical-default, peer-not-subordinate
+never: eager-agreement, yes-without-analysis
+skill: /mantra:assess (structured-assessment-workflow)
 
 ## THINKING BLOCK REQUIREMENTS (ENFORCE CHECKLISTS)
 trigger: user says "commit", "PR", "troubleshoot", or requests implementation
@@ -63,15 +61,9 @@ errors: show-full-output, analyze-thoroughly
 ## TROUBLESHOOTING & DEBUGGING (BLOCKING REQUIREMENT)
 trigger: user reports error, bug, or unexpected behavior
 priority: BLOCKING
-action: You MUST find documented evidence before proposing fixes. STOP guessing.
-troubleshoot: evidence-based-only (NO-GUESSING)
-require: multiple-documented-examples (minimum-3, not-single-source)
-sources: github-issues-first, web-search-for-real-cases, official-docs
-iterate: research-until-gaps-filled (dont-fill-with-speculation)
-never: jump-to-common-solutions, pattern-match-from-training, shotgun-debugging
-cross-reference: minimum-3-examples from authoritative-sources
-prefer: authoritative-sources (issue-trackers, changelogs, release-notes)
-when-stuck: more-research (not-guessing)
-verify: "Found N documented examples: [source1], [source2], [source3]"
-consequence: Guessing wastes time on wrong solutions and erodes trust
+action: find-documented-evidence-before-fixing (NO-GUESSING)
+require: minimum-3-documented-examples (cross-reference)
+sources: github-issues, web-search, official-docs
+never: pattern-match-from-training, shotgun-debugging
+skill: /mantra:troubleshoot (evidence-based-workflow)
 ---

--- a/onus/.claude-plugin/plugin.json
+++ b/onus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "onus",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "description": "Work item automation for Claude Code - auto-injected via hooks, zero config",
   "author": {
     "name": "David Puglielli"

--- a/onus/README.md
+++ b/onus/README.md
@@ -229,6 +229,8 @@ Every prompt shows issue status:
 | `/onus:close` | Close a work item |
 | `/onus:commit` | Create a commit with validation and format guidance |
 | `/onus:pr` | Create a pull request with validation and format guidance |
+| `/onus:status` | Show work item dashboard (issue, session, git state) |
+| `/onus:validate-criteria` | Check acceptance criteria completion before commit/PR |
 
 ## Why "onus"?
 

--- a/onus/commands/status.md
+++ b/onus/commands/status.md
@@ -1,0 +1,120 @@
+---
+description: Show current work item status and session overview
+argument-hint:
+---
+
+# Work Item Status
+
+Display a dashboard view of the current work item, session, and git state.
+
+## Task
+
+Show a consolidated view of:
+1. Current work item (from branch/cache)
+2. Session file status (from memento)
+3. Git state (branch, staged changes, commits)
+
+### Workflow
+
+1. **Detect Current Context**
+   ```bash
+   git branch --show-current
+   git status --short
+   ```
+
+2. **Load Work Item**
+   - Check onus state file: `~/.claude/onus/state.json`
+   - Load cached details: `~/.claude/onus/work-item-cache.json`
+   - If not cached, show placeholder with fetch suggestion
+
+3. **Load Session**
+   - Check `.claude/sessions/<branch>.md`
+   - Extract key sections: Goal, Status, Next Steps
+
+4. **Show Git Status**
+   - Uncommitted changes
+   - Commits ahead/behind remote
+   - Staged files
+
+### Output Format
+
+```
+## Work Item Dashboard
+
+### Current Work Item
+- **Issue**: #[number] - [title]
+- **Type**: [feature/bug/chore]
+- **Status**: [open/in-progress/in-review]
+- **URL**: [link if available]
+
+### Session
+- **File**: .claude/sessions/[filename].md
+- **Status**: [in-progress/complete]
+- **Last Updated**: [timestamp or "unknown"]
+
+### Acceptance Criteria
+- [ ] [criterion 1]
+- [x] [criterion 2 - completed]
+- [ ] [criterion 3]
+
+### Git State
+- **Branch**: [branch name]
+- **Remote**: [ahead/behind status]
+- **Staged**: [number of files or "none"]
+- **Modified**: [number of files or "none"]
+
+### Quick Actions
+- `/onus:fetch` - Refresh issue details
+- `/onus:commit` - Commit staged changes
+- `/onus:pr` - Create pull request
+- `/onus:validate-criteria` - Check criteria completion
+```
+
+## Example
+
+```
+User: /onus:status
+
+Claude: ## Work Item Dashboard
+
+### Current Work Item
+- **Issue**: #42 - Add user authentication
+- **Type**: feature
+- **Status**: open
+- **URL**: https://github.com/org/repo/issues/42
+
+### Session
+- **File**: .claude/sessions/issue-feature-42-auth.md
+- **Status**: in-progress
+- **Last Updated**: 2024-01-15
+
+### Acceptance Criteria
+- [x] Login form with email/password
+- [x] JWT token handling
+- [ ] Remember me checkbox
+- [ ] Password reset flow
+
+### Git State
+- **Branch**: issue/feature-42/auth
+- **Remote**: 2 commits ahead
+- **Staged**: none
+- **Modified**: 3 files
+
+### Quick Actions
+- `/onus:commit` - Commit your changes
+- `/onus:validate-criteria` - 2 of 4 criteria remaining
+```
+
+## When to Use
+
+Invoke this skill:
+- At the start of a work session
+- When resuming work after a break
+- When unsure of current state
+- Before creating a commit or PR
+
+## Notes
+
+- If no work item is detected, shows guidance for starting work
+- Stale cache data is marked with a warning
+- Session file absence suggests running `/memento:start`

--- a/onus/commands/validate-criteria.md
+++ b/onus/commands/validate-criteria.md
@@ -1,0 +1,100 @@
+---
+description: Check acceptance criteria completion before commit/PR
+argument-hint: [issue number or session file path]
+---
+
+# Validate Acceptance Criteria
+
+Check whether all acceptance criteria from the issue have been addressed before creating a commit or PR.
+
+## Task
+
+**IMPORTANT: This skill implements the ACCEPTANCE CRITERIA rule from work-items.md**
+
+Before committing or creating a PR, verify that all acceptance criteria have been met.
+
+### Workflow
+
+1. **Locate Criteria**
+   Find acceptance criteria from one of these sources (in priority order):
+   - Session file: `.claude/sessions/<branch>.md`
+   - Cached work item: use `/onus:fetch` if needed
+   - GitHub issue directly: `gh issue view <number>`
+
+2. **Review Each Criterion**
+   For each acceptance criterion:
+   - Check if implementation addresses it
+   - Look at relevant code changes
+   - Verify tests exist if applicable
+
+3. **Report Status**
+   Present findings with clear status for each criterion
+
+### Output Format
+
+```
+## Acceptance Criteria Validation
+
+**Issue**: #[number] - [title]
+**Branch**: [current branch]
+
+### Criteria Status
+
+| Status | Criterion | Evidence |
+|--------|-----------|----------|
+| ✅ | [criterion text] | [file:line or description] |
+| ⚠️ | [criterion text] | [partial implementation note] |
+| ❌ | [criterion text] | [not found or missing] |
+
+### Summary
+- Completed: X of Y
+- [proceed/address issues before commit]
+
+### Next Steps
+[what needs to be done for incomplete items]
+```
+
+## Example
+
+```
+User: /onus:validate-criteria
+
+Claude: ## Acceptance Criteria Validation
+
+**Issue**: #42 - Add user authentication
+**Branch**: issue/feature-42/auth
+
+### Criteria Status
+
+| Status | Criterion | Evidence |
+|--------|-----------|----------|
+| ✅ | Login form with email/password | src/components/LoginForm.tsx:15-80 |
+| ✅ | JWT token handling | src/lib/auth.ts:20-45 |
+| ✅ | Error messages for invalid credentials | src/components/LoginForm.tsx:35-50 |
+| ⚠️ | Remember me checkbox | Implemented but not tested |
+| ❌ | Password reset flow | Not started |
+
+### Summary
+- Completed: 3 of 5 (1 partial, 1 missing)
+- Address issues before commit
+
+### Next Steps
+1. Add tests for "Remember me" functionality
+2. Implement password reset flow or remove from scope
+3. Update issue if scope changed
+```
+
+## When to Use
+
+Invoke this skill:
+- Before running `/onus:commit`
+- Before running `/onus:pr`
+- When unsure if work is complete
+- During code review
+
+## Notes
+
+- Incomplete criteria doesn't always mean "don't commit"
+- Partial implementations might be intentional (phased delivery)
+- If scope changed, update the issue first
+- Session file criteria and issue criteria should match

--- a/onus/hooks/work-item.js
+++ b/onus/hooks/work-item.js
@@ -96,6 +96,20 @@ function detectPlatform(issueKey) {
   return 'github';
 }
 
+/**
+ * Get the commit format string, handling both legacy string format
+ * and new object format with {issue, chore} keys.
+ */
+function getCommitFormat(commitFormat, type = 'issue') {
+  if (typeof commitFormat === 'string') {
+    return commitFormat;
+  }
+  if (typeof commitFormat === 'object' && commitFormat !== null) {
+    return commitFormat[type] || commitFormat.issue || '{number} - {verb} {description}';
+  }
+  return '{number} - {verb} {description}';
+}
+
 // ============================================================================
 // Work Item Cache
 // ============================================================================
@@ -185,7 +199,7 @@ function formatWorkItemContext(workItem, cfg) {
     parts.push(`⚠️ Issue details not yet fetched. Use \`/fetch ${workItem.key}\` to load details.`);
     parts.push('');
     parts.push('**Commit format reminder:**');
-    parts.push(`\`${cfg.commitFormat.replace('{number}', workItem.key)}\``);
+    parts.push(`\`${getCommitFormat(cfg.commitFormat).replace('{number}', workItem.key)}\``);
     return parts.join('\n');
   }
 
@@ -218,7 +232,7 @@ function formatWorkItemContext(workItem, cfg) {
 
   parts.push('');
   parts.push('**Commit format:**');
-  parts.push(`\`${cfg.commitFormat.replace('{number}', workItem.key)}\``);
+  parts.push(`\`${getCommitFormat(cfg.commitFormat).replace('{number}', workItem.key)}\``);
 
   if (workItem.stale) {
     parts.push('');
@@ -332,7 +346,7 @@ function onUserPromptSubmit(input, base) {
     context += `\n📋 Issue: ${state.currentIssue}`;
   }
   if (staged) {
-    context += `\n💡 Staged changes detected. Commit format: \`${cfg.commitFormat.replace('{number}', state.currentIssue || 'N')}\``;
+    context += `\n💡 Staged changes detected. Commit format: \`${getCommitFormat(cfg.commitFormat).replace('{number}', state.currentIssue || 'N')}\``;
   }
 
   return {
@@ -395,6 +409,7 @@ module.exports = {
   hasStagedChanges,
   extractIssueFromBranch,
   detectPlatform,
+  getCommitFormat,
   getCachedWorkItem,
   createPlaceholderWorkItem,
   formatWorkItemContext,

--- a/onus/package.json
+++ b/onus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/onus",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "description": "Work item automation plugin for Claude Code - auto-injected via hooks, zero config",
   "main": "index.js",
   "scripts": {

--- a/onus/rules/work-items.md
+++ b/onus/rules/work-items.md
@@ -11,6 +11,7 @@ type: reference
 detect: branch-name-first (issue/feature-N, PROJ-123, #N)
 inject: session-start (full-context), prompt (status-line)
 platforms: github-issues, jira, azure-devops
+skill: /onus:status (dashboard-view)
 
 ## GIT CONVENTIONS
 see: git.md (commit-format, branch-naming, pr-format)
@@ -23,9 +24,8 @@ comments: milestone-updates, blockers, decisions
 
 ## ACCEPTANCE CRITERIA
 track: checkbox-list (from issue description)
-validate: before-commit (did-we-address-this?)
-warn: unaddressed-criteria (before PR)
-format: "- [ ] criterion" -> "- [x] criterion" (when done)
+validate: before-commit, before-PR
+skill: /onus:validate-criteria (check-completion)
 
 ## SESSION INTEGRATION
 with-memento: populate-session-from-issue


### PR DESCRIPTION
## Summary
- Add 4 Phase 2 skills for explicit invocation:
  - `/mantra:assess` - Structured critical assessment (correctness, architecture, alternatives, risks)
  - `/mantra:troubleshoot` - Evidence-based debugging (requires 3+ documented examples)
  - `/onus:validate-criteria` - Check acceptance criteria completion before commit/PR
  - `/onus:status` - Work item dashboard (issue, session, git state)
- Fix onus hook crash when `commitFormat` is an object instead of string
- Fix statusline regex to match GitHub issue numbers (1-6 digits instead of 5-6)
- Streamline rules to reference skills, reducing initial context token usage
- Update READMEs with new commands

## Test plan
- [x] All tests pass (mantra 25, memento 42, onus 65 = 132 total)
- [x] New `getCommitFormat` helper tested with string and object formats
- [ ] Verify skills appear in `/skills` list after plugin update
- [ ] Test each skill manually

Closes #117