### PR TITLE
chore - minimal herd naming (rely on herdr defaults; handles + tab glyphs only)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
       "name": "comitatus",
       "source": "./comitatus",
       "description": "herdr workflows - packages the herdr agent-orchestration skill for claude and codex, auto-injected inside herdr",
-      "version": "0.1.0"
+      "version": "0.1.1"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
       "name": "comitatus",
       "source": "./comitatus",
       "description": "herdr workflows - packages the herdr agent-orchestration skill for claude and codex, auto-injected inside herdr",
-      "version": "0.1.1"
+      "version": "0.1.2"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
       "name": "comitatus",
       "source": "./comitatus",
       "description": "herdr workflows - packages the herdr agent-orchestration skill for claude and codex, auto-injected inside herdr",
-      "version": "0.1.2"
+      "version": "0.1.3"
     }
   ]
 }

--- a/comitatus/package.json
+++ b/comitatus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/comitatus",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "herdr workflows plugin for Claude Code - packages the herdr skill, auto-injected inside herdr",
   "main": "hooks/herdr-orient.js",
   "scripts": {

--- a/comitatus/package.json
+++ b/comitatus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/comitatus",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "herdr workflows plugin for Claude Code - packages the herdr skill, auto-injected inside herdr",
   "main": "hooks/herdr-orient.js",
   "scripts": {

--- a/comitatus/package.json
+++ b/comitatus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/comitatus",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "herdr workflows plugin for Claude Code - packages the herdr skill, auto-injected inside herdr",
   "main": "hooks/herdr-orient.js",
   "scripts": {

--- a/comitatus/skills/herdr/SKILL.md
+++ b/comitatus/skills/herdr/SKILL.md
@@ -33,27 +33,27 @@ three facts that drive most workflows:
 
 ids are short: workspace `w8`, tab `w8:t1`, pane `w8:p1`. they are opaque and **not durable** - they can change as things open and close. never reuse an old id; re-read the current one from `worktree list`, `workspace list`, `agent list`, or a create/start response. most commands print json, so parse ids out of the json rather than guessing.
 
-## naming (repo -> task -> members)
+## naming (repo -> worktree -> members)
 
-a convention layered on top of herdr - herdr stores **none** of it. three tiers; the first two are **labeled descriptively** (after what they are / do), the third draws a call-sign from a pool in [reference/names.md](reference/names.md):
+a convention layered on top of herdr - herdr stores **none** of it. three tiers; the first two are **labeled descriptively** (after what they are / where they run), the third draws a call-sign from a pool in [reference/names.md](reference/names.md):
 
 - **herder** - the top-level orchestrator workspace, **one per herdr session** (the home repo's main checkout; a second repo = a second session = a second herder). label it with a short **repo tag** - `claude-dom`, ... - via `workspace rename <ws> "<repo-tag>"`.
-- **herd** - a managed group of agents. label its workspace with a short **task tag** that says what the group is doing - `comitatus`, `terraform`, ... - derived from the branch, unique among live herd workspaces.
+- **herd** - a managed group of agents. label its workspace with its **worktree name** (the worktree's directory) - `chore-comitatus-fixes`, `chore-refactor-terraform`, ... - so the sidebar says exactly which worktree it is. (a herd not on a worktree has no worktree name; give it a short descriptive tag instead.)
 - **member** - an agent in a herd. its **handle** is a short call-sign - `tim`, `jay`, `sly`, ... - claimed as the next unused pool entry, set with `agent rename <pane> <handle>`.
 
-**why only members get pooled names.** a herd/herder label answers "what / where": the sidebar row is `<workspace> · <tab>` and the branch is **not** in it, so the workspace label is your only at-a-glance "what is this group doing" field - a task/repo tag spends it well, an arbitrary noun wastes it. a member handle is different: it is the **addressable identity** (`agent send tim`), so it must stay short, unique, phonetically distinct, and stable across a model relaunch - none of which a task name (many members per task) can be. so members draw from a pool; herds and herders are named after their work.
+**why only members get pooled names.** a herd/herder label answers "what / where": the sidebar row is `<workspace> · <tab>` and the branch is **not** in it, so the workspace label is your only at-a-glance "which worktree is this" field - the worktree name (herd) or repo tag (herder) spends it well, an arbitrary noun wastes it. a member handle is different: it is the **addressable identity** (`agent send tim`), so it must stay short, unique, phonetically distinct, and stable across a model relaunch - none of which a worktree name (many members per worktree) can be. so members draw from a pool; herds and herders are named after their work.
 
-**picking a task / repo tag.** a short, readable abbreviation of the branch (herd) or repo (herder) - judgment, not an algorithm: `chore/comitatus-fixes -> comitatus`, `chore/refactor-terraform -> terraform`, `issue/feature-3/add-socius -> socius`. keep it **<= ~10 chars** (see the labels rule) and unique among live herds; on a genuine collision qualify one (`tf-refac` / `api-refac`), though their repo groups already separate them in the sidebar.
+**picking the label.** a herd's label is its **worktree directory name** verbatim - the basename of `~/.herdr/worktrees/<repo>/<branch-slug>` (`chore/comitatus-fixes -> chore-comitatus-fixes`). a herder's label is a short **repo tag** (`claude-domestique -> claude-dom`). a worktree name is long and **truncates the decorated tab label in the collapsed sidebar** (see the labels rule) - that is an accepted trade for a label that names the worktree unambiguously; the handle reappears when you focus or widen the workspace.
 
-**fully-qualified vs addressable.** a member's full identity is written `<repo>/<task>/<member>` (e.g. `claude-domestique/comitatus/fox`) for humans and docs. but herdr has **no hierarchical addressing**: the only thing it stores or routes is the flat member handle, and you reach the agent with `agent send fox`. the `<repo>/` and `<task>/` segments are operator bookkeeping (which herder owns which herd is convention, not herdr state), not part of the address.
+**fully-qualified vs addressable.** a member's full identity is written `<repo>/<worktree>/<member>` (e.g. `claude-domestique/chore-comitatus-fixes/fox`) for humans and docs. but herdr has **no hierarchical addressing**: the only thing it stores or routes is the flat member handle, and you reach the agent with `agent send fox`. the `<repo>/` and `<worktree>/` segments are operator bookkeeping (which herder owns which herd is convention, not herdr state), not part of the address.
 
 rules that make it work:
 
 - **member handles are globally unique - herdr enforces it.** a duplicate `agent start` is rejected (`agent_name_taken`, verified), across *all* workspaces. claim each handle against live `agent list`; size the member pool above your peak concurrent agent count.
-- **labels <= ~10 chars.** rows render `<workspace> · <tab>`, so a long herder/herd label truncates the member's decorated tab label - abbreviate the task/repo tag to fit.
-- **handles are type-agnostic.** never encode the model in a handle; the tab already shows `◆ claude` / `◇ codex`, and a type-free handle survives relaunching a member on another model.
-- **labels track the work.** a herd's label follows its task: reassign the herd to a new branch and you **relabel** it to the new task tag (`workspace rename`). the work is still found via cwd, not the label - but the label is kept descriptive on purpose, so the sidebar always reads true.
-- **only home-repo worktrees nest under the herder.** a herd appears *under* the herder in the panel only when it's a linked worktree of the session's repo; plain workspaces and any other repo float separately (logical-only herds - the `<repo>/<task>/...` path still names them, they just don't nest visually).
+- **the workspace label can truncate the tab label.** rows render `<workspace> · <tab>`, so a long workspace label (a full worktree name) truncates the member's decorated `<handle> <glyph>` tab label in the collapsed sidebar - the handle reappears on focus/widen. keep the **herder** repo tag short (~10 chars); a **herd** keeps its full worktree name and accepts the trade.
+- **handles are type-agnostic.** never encode the model in a handle; the tab already shows the model glyph (`◆` / `◇`), and a type-free handle survives relaunching a member on another model.
+- **labels track the worktree.** a herd's label is its worktree name: reassign the herd to a new worktree and you **relabel** it to the new worktree name (`workspace rename`). the work is still found via cwd, not the label - but the label is kept descriptive on purpose, so the sidebar always reads true.
+- **only home-repo worktrees nest under the herder.** a herd appears *under* the herder in the panel only when it's a linked worktree of the session's repo; plain workspaces and any other repo float separately (logical-only herds - the `<repo>/<worktree>/...` path still names them, they just don't nest visually).
 - **phonetic distinctness for members.** they message each other by handle in the from/to protocol and weak local models mis-type look-alikes - avoid rhyming clusters.
 
 ## discover state
@@ -109,8 +109,8 @@ WT=~/.herdr/worktrees/<repo>/chore-my-slug
 WS=wR            # worktree's open_workspace_id from step 1
 ROOT1=wR:p1      # worktree's root_pane from step 1
 
-herdr workspace rename "$WS" "my-slug"        # keep this SHORT (see gotchas): rows render "<workspace> · <tab>"
-herdr tab rename "${WS}:t1" "sly ◆ claude"    # tab label carries the decorated <handle> <glyph> <type>
+herdr workspace rename "$WS" "chore-my-slug"  # the worktree name (its dir basename); a herder gets a short repo tag instead
+herdr tab rename "${WS}:t1" "sly ◆"    # tab label carries the decorated <handle> <glyph>
 
 # agent 1 in the worktree's root pane (tab 1)
 herdr pane run "$ROOT1" "claude"
@@ -118,7 +118,7 @@ herdr wait agent-status "$ROOT1" --status idle --timeout 40000
 herdr agent rename "$ROOT1" sly
 
 # each additional agent: a new tab, run the model in its root pane, detect, name
-T=$(herdr tab create --workspace "$WS" --cwd "$WT" --label "jay ◇ codex" --no-focus)
+T=$(herdr tab create --workspace "$WS" --cwd "$WT" --label "jay ◇" --no-focus)
 ROOT=$(echo "$T" | node "$H" field result.root_pane.pane_id)
 herdr pane run "$ROOT" "codex"
 herdr wait agent-status "$ROOT" --status idle --timeout 40000
@@ -127,13 +127,13 @@ herdr agent rename "$ROOT" jay
 
 | model | `pane run` argv | glyph | tab label |
 |---|---|---|---|
-| claude | `claude` | ◆ | `sly ◆ claude` |
-| codex | `codex` | ◇ | `jay ◇ codex` |
-| opencode + qwen2.5:7b | `opencode -m ollama/qwen2.5:7b` | ⬨ | `bob ⬨ opencode` |
+| claude | `claude` | ◆ | `sly ◆` |
+| codex | `codex` | ◇ | `jay ◇` |
+| opencode + qwen2.5:7b | `opencode -m ollama/qwen2.5:7b` | ⬨ | `bob ⬨` |
 
 - `--cwd "$WT"` on `tab create` keeps each agent's working dir on the worktree (association is by cwd).
 - `agent rename` needs the agent **detected first**; that is what `wait agent-status` ensures.
-- the decorated `<handle> <glyph> <type>` format lives on the **tab** label. keep the workspace label short, or rows truncate.
+- the decorated `<handle> <glyph>` format lives on the **tab** label; the workspace label is a separate axis (the worktree name - see `## naming`).
 - `agent start <handle> --cwd "$WT" --workspace <ws> -- <argv>` is an escape hatch for an ad-hoc agent pane, but it does not give the clean one-tab-per-agent grouping - prefer tabs. see reference/cli.md.
 
 ### 4. assign or change a handle
@@ -144,7 +144,7 @@ step 3 sets the handle with `herdr agent rename <pane> <handle>`. to change it l
 herdr agent rename sly sly2
 ```
 
-the handle is also the pane label. the decorated **tab** label (step 3) does **not** auto-update - `herdr tab rename <tab> "sly2 ◆ claude"` if you want it to match.
+the handle is also the pane label. the decorated **tab** label (step 3) does **not** auto-update - `herdr tab rename <tab> "sly2 ◆"` if you want it to match.
 
 ### 5. message another agent by handle
 
@@ -192,8 +192,8 @@ WT=$(echo "$OUT"    | node "$H" field result.worktree.path)
 WS=$(echo "$OUT"    | node "$H" field result.worktree.open_workspace_id)
 ROOT1=$(echo "$OUT" | node "$H" field result.root_pane.pane_id)
 
-herdr workspace rename "$WS" "review-x"
-herdr tab rename "${WS}:t1" "sly ◆ claude"
+herdr workspace rename "$WS" "chore-review-x"
+herdr tab rename "${WS}:t1" "sly ◆"
 
 # sly = claude in tab 1 (the worktree's root pane)
 herdr pane run "$ROOT1" "claude"
@@ -201,7 +201,7 @@ herdr wait agent-status "$ROOT1" --status idle --timeout 40000
 herdr agent rename "$ROOT1" sly
 
 # jay = codex in a second tab of the same workspace
-T=$(herdr tab create --workspace "$WS" --cwd "$WT" --label "jay ◇ codex" --no-focus)
+T=$(herdr tab create --workspace "$WS" --cwd "$WT" --label "jay ◇" --no-focus)
 ROOT2=$(echo "$T" | node "$H" field result.root_pane.pane_id)
 herdr pane run "$ROOT2" "codex"
 herdr wait agent-status "$ROOT2" --status idle --timeout 40000
@@ -223,7 +223,7 @@ git branch -D chore/review-x
 
 ### assign a herd to a worktree
 
-the common case: assign a herd to its own **worktree** (isolated branch + dir). that is just step 1 (create the worktree) then step 3 (attach each agent as a tab): agent 1 in the worktree's root tab, each additional agent in its own `tab create --workspace <ws> --cwd <wt>`. nothing extra - the herd is simply the agents you launched with that worktree's cwd. name the workspace with a **task tag** and each member with a **handle** from the pool (see `## naming`); the step-3 recipe's `workspace rename` / `tab rename` / `agent rename` are where those names land.
+the common case: assign a herd to its own **worktree** (isolated branch + dir). that is just step 1 (create the worktree) then step 3 (attach each agent as a tab): agent 1 in the worktree's root tab, each additional agent in its own `tab create --workspace <ws> --cwd <wt>`. nothing extra - the herd is simply the agents you launched with that worktree's cwd. name the workspace with its **worktree name** and each member with a **handle** from the pool (see `## naming`); the step-3 recipe's `workspace rename` / `tab rename` / `agent rename` are where those names land.
 
 a herd does **not** require a worktree. launch one at any cwd - most usefully the **main checkout** (a plain branch): `herdr workspace create --cwd <repo>`, then attach agents there. caveat: a plain-branch herd shares the **single** repo checkout, so "reassign to a different branch" is a global `git checkout` with no isolation - prefer a worktree when you want a herd pinned to its own branch without disturbing other work.
 
@@ -241,7 +241,7 @@ ROOT1=$(echo "$NEW" | node "$H" field result.root_pane.pane_id)
 herdr workspace close <old-herd-ws>            # take the OLD herd down -> frees the handles (sly/jay/tim)
 
 # rebuild each agent on the new worktree, reusing the SAME handles (the assign / step-3 recipe):
-herdr tab rename "${WS}:t1" "sly ◆ claude"; herdr pane run "$ROOT1" "claude"
+herdr tab rename "${WS}:t1" "sly ◆"; herdr pane run "$ROOT1" "claude"
 herdr wait agent-status "$ROOT1" --status idle --timeout 45000; herdr agent rename "$ROOT1" sly
 # jay -> tab create + pane run "codex" + rename jay ;  tim -> tab create + "claude --model haiku" + rename tim
 
@@ -335,12 +335,12 @@ herdr wait agent-status w9:p1 --status done --timeout 120000   # a sibling finis
 - **codex TUI paste gotcha** - a long `send-text` / `agent send` into a codex TUI may be ingested as a bracketed paste that a single Enter does not submit. keep protocol messages one line and short. if you deliberately send a long codex message and silence follows, send one extra Enter or retry as shorter one-line chunks.
 - **opencode status needs the fix plugin** - herdr 0.7.0's managed opencode integration is out of date with opencode 1.17.8 (object-form `session.status` + fire-and-forget idle), so opencode agents get stuck `working` / never report state right. the sibling plugin `~/.config/opencode/plugins/herdr-opencode-status-fix.js` restores correct working/idle/blocked reporting. without it, `wait agent-status` on an opencode pane is unreliable.
 - **only the home repo's worktree tree nests; plain workspaces don't** - the sidebar nests exactly one repo group (main checkout -> its linked worktrees -> tabs), keyed on `repo_root`. a `workspace create --cwd` workspace gets **no** repo association and floats ungrouped, even at a repo root. give each agent in a herd a *tab* in the herd's one workspace; make the herd a worktree if you want it to nest under the herder.
-- **keep the workspace label short** - agent rows render as `<workspace> · <tab>`, so a long workspace label truncates the decorated tab label; keep the task/repo tag <= ~10 chars.
+- **workspace label vs tab truncation** - agent rows render as `<workspace> · <tab>`, so a long workspace label (a full worktree name) truncates the decorated `<handle> <glyph>` tab label in the collapsed sidebar; the handle reappears on focus/widen. keep the **herder** repo tag short (~10 chars); a **herd** keeps its full worktree name (see `## naming`).
 - **`worktree remove` keeps the branch** - it removes the git worktree, its directory, the workspace, and all that workspace's tabs/agents, but not the branch (`git branch -D` separately).
 - **`open` reattaches, `create` makes new branches** - `worktree open` opens a workspace on a worktree that *already exists* (errors `worktree_not_found` otherwise, **including** any worktree of a repo this session does not track); `worktree create --branch` only makes a *new* branch (errors if it exists). existing branch with no worktree -> `git worktree add` first, then `open` (only works for the home repo).
 - **one repo per herdr session** - `worktree create` ignores the CLI cwd and always builds in the session's home/launch repo (verified: invoking it with cwd set to a different repo still produced a home-repo worktree). there is no way to manage a second repo's worktrees from one session; launch a separate `herdr --session <name>` inside that repo - that *is* a second herder.
 - **detect before `agent rename`** - a model launched with `pane run` is only renameable once herdr detects it. `herdr wait agent-status <pane> --status idle` first, or the rename misses the target.
-- **decorated labels are manual** - `sly ◆ claude` style labels are set with `tab rename`, not auto-derived. renaming the handle does not update the tab label; re-`tab rename` to keep them in sync.
+- **decorated labels are manual** - `sly ◆` style labels are set with `tab rename`, not auto-derived. renaming the handle does not update the tab label; re-`tab rename` to keep them in sync.
 - **`agent start` needs both `--cwd` and `--workspace`** - the ad-hoc escape hatch (vs the default `pane run` in a tab) takes `--cwd <worktree-path>` for the working dir (the cwd association `agent list` uses) and `--workspace <id>` for pane placement; they are independent. `--workspace` alone leaves the agent on *your* cwd, editing the wrong tree.
 - **cwd is the resolved path** - herdr stores an agent's `cwd` OS-resolved, so a symlinked root differs from what you launched with (macOS `/tmp` -> `/private/tmp`). when you filter `agent list` by cwd to find a herd, compare against the resolved path (`cd <dir>; pwd -P`), not the string you passed, or you'll see zero agents on a herd that is running fine.
 - **ids are not durable** - re-read them; never reuse an old id.

--- a/comitatus/skills/herdr/SKILL.md
+++ b/comitatus/skills/herdr/SKILL.md
@@ -21,7 +21,7 @@ herdr nests like this: **repo -> worktree -> workspace -> tab -> pane -> agent**
 - **pane** - a real terminal split. runs a shell, an agent, a server, anything.
 - **agent** - a coding agent (claude, codex, opencode, ...) running in a pane. each agent carries a **handle** in its `name` field (e.g. `fox`, `ivy`). you address agents by handle.
 - **herd** - a *group of agents you treat as a team*: 1..n members, models mixed freely (claude, codex, opencode/local, ...). a herd is a **logical roster, not a herdr object** - there is no `herd` command and no herd field on anything; it is **orthogonal** to the worktree->...->agent nesting above. a herd can run on a worktree, on the main checkout (a plain branch), or at any cwd; and a worktree can exist with **no** herd at all. members know the roster and message each other - and members of *other* herds - by handle (see the from/to protocol). "assigning a herd to work" just means launching its agents with their `cwd` at that work (a worktree dir or a branch checkout).
-- **herder** - the top-level orchestrator (a workspace; you, reading this, are one) that spins up and tends herds. **exactly one per herdr session** - it is the session's home repo (the single main-checkout anchor every worktree-herd nests under). a second repo means a second herdr session, i.e. a second herder; you cannot manage two repos from one session (`worktree create` always targets the home repo). herder and herd are **labeled descriptively** (by repo and by task); only member handles come from a name pool - all convention, no herdr enforcement - see `## naming` below.
+- **home repo / main checkout** - every herdr session is anchored to one repo, and you spin up and tend herds from its **main-checkout workspace** (the one you, reading this, are launched under). **exactly one repo per session** - the main checkout is the single anchor every worktree nests under; a second repo means a second herdr session (`worktree create` always targets the home repo, and must be run from its main-checkout workspace). nothing here is named by convention: herdr labels the main checkout with the repo name and each worktree with its directory name - you leave both. only member handles are assigned - see `## naming` below.
 
 three facts that drive most workflows:
 
@@ -33,27 +33,25 @@ three facts that drive most workflows:
 
 ids are short: workspace `w8`, tab `w8:t1`, pane `w8:p1`. they are opaque and **not durable** - they can change as things open and close. never reuse an old id; re-read the current one from `worktree list`, `workspace list`, `agent list`, or a create/start response. most commands print json, so parse ids out of the json rather than guessing.
 
-## naming (repo -> worktree -> members)
+## naming (worktree -> members)
 
-a convention layered on top of herdr - herdr stores **none** of it. three tiers; the first two are **labeled descriptively** (after what they are / where they run), the third draws a call-sign from a pool in [reference/names.md](reference/names.md):
+a thin convention on top of herdr - herdr stores **none** of it. you assign exactly two things; every workspace/worktree label is left at herdr's default:
 
-- **herder** - the top-level orchestrator workspace, **one per herdr session** (the home repo's main checkout; a second repo = a second session = a second herder). label it with a short **repo tag** - `claude-dom`, ... - via `workspace rename <ws> "<repo-tag>"`.
-- **herd** - a managed group of agents. label its workspace with its **worktree name** (the worktree's directory) - `chore-comitatus-fixes`, `chore-refactor-terraform`, ... - so the sidebar says exactly which worktree it is. (a herd not on a worktree has no worktree name; give it a short descriptive tag instead.)
-- **member** - an agent in a herd. its **handle** is a short call-sign - `tim`, `jay`, `sly`, ... - claimed as the next unused pool entry, set with `agent rename <pane> <handle>`.
+- **herd** - a group of agents on a worktree. **you don't label it.** when you `worktree create`, herdr already labels the worktree's workspace with the **worktree directory name** (`chore-comitatus-fixes`) - exactly what you want in the sidebar row. (the repo's main checkout is left at its default too: herdr labels it the repo name, `claude-domestique`.)
+- **member** - an agent in a herd. its **handle** is a short call-sign - `tim`, `jay`, `sly`, ... - claimed as the next unused entry from the pool in [reference/names.md](reference/names.md), set with `agent rename <pane> <handle>`. the handle is the **addressable identity** (`agent send tim`), so it must stay short, unique, phonetically distinct, and stable across a model relaunch.
 
-**why only members get pooled names.** a herd/herder label answers "what / where": the sidebar row is `<workspace> · <tab>` and the branch is **not** in it, so the workspace label is your only at-a-glance "which worktree is this" field - the worktree name (herd) or repo tag (herder) spends it well, an arbitrary noun wastes it. a member handle is different: it is the **addressable identity** (`agent send tim`), so it must stay short, unique, phonetically distinct, and stable across a model relaunch - none of which a worktree name (many members per worktree) can be. so members draw from a pool; herds and herders are named after their work.
+the agent's decorated **tab** label is `<handle> <glyph>` (`fox ◆`, `jay ◇`), set with `tab rename` (the glyph - claude `◆`, codex `◇`, opencode `⬨` - encodes the model). the handle and that tab label are the **only** labels you assign; workspace and worktree labels are herdr's defaults and are never renamed. the sidebar row is `<workspace> · <tab>` = `<worktree-name> · <handle> <glyph>`, which reads true with zero renaming.
 
-**picking the label.** a herd's label is its **worktree directory name** verbatim - the basename of `~/.herdr/worktrees/<repo>/<branch-slug>` (`chore/comitatus-fixes -> chore-comitatus-fixes`). a herder's label is a short **repo tag** (`claude-domestique -> claude-dom`). a worktree name is long and **truncates the decorated tab label in the collapsed sidebar** (see the labels rule) - that is an accepted trade for a label that names the worktree unambiguously; the handle reappears when you focus or widen the workspace.
+**why members are the exception.** a member handle is an identity you *route messages to*, so it has to be assigned and stable. a workspace label, by contrast, herdr already derives correctly from the worktree - there is nothing to assign, so don't.
 
-**fully-qualified vs addressable.** a member's full identity is written `<repo>/<worktree>/<member>` (e.g. `claude-domestique/chore-comitatus-fixes/fox`) for humans and docs. but herdr has **no hierarchical addressing**: the only thing it stores or routes is the flat member handle, and you reach the agent with `agent send fox`. the `<repo>/` and `<worktree>/` segments are operator bookkeeping (which herder owns which herd is convention, not herdr state), not part of the address.
+**addressing.** a member is reached by its flat handle - `agent send fox`. herdr has **no hierarchical addressing**; for humans you may write `<repo>/<worktree>/<member>` (e.g. `claude-domestique/chore-comitatus-fixes/fox`), but only the handle is real.
 
 rules that make it work:
 
 - **member handles are globally unique - herdr enforces it.** a duplicate `agent start` is rejected (`agent_name_taken`, verified), across *all* workspaces. claim each handle against live `agent list`; size the member pool above your peak concurrent agent count.
-- **the workspace label can truncate the tab label.** rows render `<workspace> · <tab>`, so a long workspace label (a full worktree name) truncates the member's decorated `<handle> <glyph>` tab label in the collapsed sidebar - the handle reappears on focus/widen. keep the **herder** repo tag short (~10 chars); a **herd** keeps its full worktree name and accepts the trade.
-- **handles are type-agnostic.** never encode the model in a handle; the tab already shows the model glyph (`◆` / `◇`), and a type-free handle survives relaunching a member on another model.
-- **labels track the worktree.** a herd's label is its worktree name: reassign the herd to a new worktree and you **relabel** it to the new worktree name (`workspace rename`). the work is still found via cwd, not the label - but the label is kept descriptive on purpose, so the sidebar always reads true.
-- **only home-repo worktrees nest under the herder.** a herd appears *under* the herder in the panel only when it's a linked worktree of the session's repo; plain workspaces and any other repo float separately (logical-only herds - the `<repo>/<worktree>/...` path still names them, they just don't nest visually).
+- **a worktree name is long and can truncate the tab label.** rows render `<workspace> · <tab>`, so the worktree-name workspace label can push the decorated `<handle> <glyph>` tab label off the collapsed sidebar - the handle reappears on focus/widen. that is the trade for a label that names the worktree unambiguously, and it costs no renaming.
+- **handles are type-agnostic.** never encode the model in a handle; the tab glyph already shows it, and a type-free handle survives relaunching a member on another model.
+- **only home-repo worktrees nest under the main checkout.** a herd appears *under* the repo's main checkout in the panel only when it's a linked worktree of the session's repo; plain workspaces and any other repo float separately (the `<repo>/<worktree>/...` path still names them, they just don't nest visually).
 - **phonetic distinctness for members.** they message each other by handle in the from/to protocol and weak local models mis-type look-alikes - avoid rhyming clusters.
 
 ## discover state
@@ -75,7 +73,7 @@ these are the small, composable operations. chain them for bigger flows.
 
 ```bash
 git fetch origin main
-herdr worktree create --branch chore/my-slug --base origin/main --label "my slug" --no-focus --json
+herdr worktree create --branch chore/my-slug --base origin/main --no-focus --json   # workspace auto-labels as "chore-my-slug" (the worktree dir)
 ```
 
 the branch name carries the work item (`123456-slug`) or a chore (`chore/slug`). the new checkout lands at `~/.herdr/worktrees/<repo>/<branch-slug>` (slashes become dashes, lowercased); pass `--path` to override. grab the new workspace id from `result.worktree.open_workspace_id`.
@@ -109,8 +107,8 @@ WT=~/.herdr/worktrees/<repo>/chore-my-slug
 WS=wR            # worktree's open_workspace_id from step 1
 ROOT1=wR:p1      # worktree's root_pane from step 1
 
-herdr workspace rename "$WS" "chore-my-slug"  # the worktree name (its dir basename); a herder gets a short repo tag instead
-herdr tab rename "${WS}:t1" "sly ◆"    # tab label carries the decorated <handle> <glyph>
+# no workspace rename: herdr already labeled "$WS" with the worktree dir name ("chore-my-slug")
+herdr tab rename "${WS}:t1" "sly ◆"    # the ONLY label you set: the decorated <handle> <glyph> tab label
 
 # agent 1 in the worktree's root pane (tab 1)
 herdr pane run "$ROOT1" "claude"
@@ -192,8 +190,7 @@ WT=$(echo "$OUT"    | node "$H" field result.worktree.path)
 WS=$(echo "$OUT"    | node "$H" field result.worktree.open_workspace_id)
 ROOT1=$(echo "$OUT" | node "$H" field result.root_pane.pane_id)
 
-herdr workspace rename "$WS" "chore-review-x"
-herdr tab rename "${WS}:t1" "sly ◆"
+herdr tab rename "${WS}:t1" "sly ◆"    # workspace "$WS" is already labeled "chore-review-x" by herdr
 
 # sly = claude in tab 1 (the worktree's root pane)
 herdr pane run "$ROOT1" "claude"
@@ -223,7 +220,7 @@ git branch -D chore/review-x
 
 ### assign a herd to a worktree
 
-the common case: assign a herd to its own **worktree** (isolated branch + dir). that is just step 1 (create the worktree) then step 3 (attach each agent as a tab): agent 1 in the worktree's root tab, each additional agent in its own `tab create --workspace <ws> --cwd <wt>`. nothing extra - the herd is simply the agents you launched with that worktree's cwd. name the workspace with its **worktree name** and each member with a **handle** from the pool (see `## naming`); the step-3 recipe's `workspace rename` / `tab rename` / `agent rename` are where those names land.
+the common case: assign a herd to its own **worktree** (isolated branch + dir). that is just step 1 (create the worktree) then step 3 (attach each agent as a tab): agent 1 in the worktree's root tab, each additional agent in its own `tab create --workspace <ws> --cwd <wt>`. nothing extra - the herd is simply the agents you launched with that worktree's cwd. herdr already labels the workspace with the worktree name, so all you assign is each member's **handle** plus its decorated `<handle> <glyph>` tab label (see `## naming`); the step-3 recipe's `tab rename` / `agent rename` are where those land.
 
 a herd does **not** require a worktree. launch one at any cwd - most usefully the **main checkout** (a plain branch): `herdr workspace create --cwd <repo>`, then attach agents there. caveat: a plain-branch herd shares the **single** repo checkout, so "reassign to a different branch" is a global `git checkout` with no isolation - prefer a worktree when you want a herd pinned to its own branch without disturbing other work.
 
@@ -233,7 +230,7 @@ an agent's **cwd is fixed at launch**, and herdr keys worktree-association on cw
 
 ```bash
 git fetch origin main
-NEW=$(herdr worktree create --branch chore/new-slug --base origin/main --label "new-slug" --no-focus --json)
+NEW=$(herdr worktree create --branch chore/new-slug --base origin/main --no-focus --json)   # workspace auto-labels as "chore-new-slug"
 WS=$(echo "$NEW"    | node "$H" field result.worktree.open_workspace_id)
 WT=$(echo "$NEW"    | node "$H" field result.worktree.path)
 ROOT1=$(echo "$NEW" | node "$H" field result.root_pane.pane_id)
@@ -334,11 +331,12 @@ herdr wait agent-status w9:p1 --status done --timeout 120000   # a sibling finis
 - **`agent send` has no Enter, and the Enter drops only while the target is `working`** - send + `pane send-keys <pane> Enter` and let the reply confirm it landed (resend on silence); only for a no-reply message poll until the target is not `working` first, or verify by reading its pane. don't blindly double-tap. (full recipe in the from/to protocol section.)
 - **codex TUI paste gotcha** - a long `send-text` / `agent send` into a codex TUI may be ingested as a bracketed paste that a single Enter does not submit. keep protocol messages one line and short. if you deliberately send a long codex message and silence follows, send one extra Enter or retry as shorter one-line chunks.
 - **opencode status needs the fix plugin** - herdr 0.7.0's managed opencode integration is out of date with opencode 1.17.8 (object-form `session.status` + fire-and-forget idle), so opencode agents get stuck `working` / never report state right. the sibling plugin `~/.config/opencode/plugins/herdr-opencode-status-fix.js` restores correct working/idle/blocked reporting. without it, `wait agent-status` on an opencode pane is unreliable.
-- **only the home repo's worktree tree nests; plain workspaces don't** - the sidebar nests exactly one repo group (main checkout -> its linked worktrees -> tabs), keyed on `repo_root`. a `workspace create --cwd` workspace gets **no** repo association and floats ungrouped, even at a repo root. give each agent in a herd a *tab* in the herd's one workspace; make the herd a worktree if you want it to nest under the herder.
-- **workspace label vs tab truncation** - agent rows render as `<workspace> · <tab>`, so a long workspace label (a full worktree name) truncates the decorated `<handle> <glyph>` tab label in the collapsed sidebar; the handle reappears on focus/widen. keep the **herder** repo tag short (~10 chars); a **herd** keeps its full worktree name (see `## naming`).
+- **only the home repo's worktree tree nests; plain workspaces don't** - the sidebar nests exactly one repo group (main checkout -> its linked worktrees -> tabs), keyed on `repo_root`. a `workspace create --cwd` workspace gets **no** repo association and floats ungrouped, even at a repo root. give each agent in a herd a *tab* in the herd's one workspace; make the herd a worktree if you want it to nest under the repo's main checkout.
+- **workspace label vs tab truncation** - agent rows render as `<workspace> · <tab>`, and herdr labels a worktree's workspace with its (long) directory name, so the decorated `<handle> <glyph>` tab label can truncate in the collapsed sidebar; the handle reappears on focus/widen. that label is herdr's default - you don't rename it (see `## naming`).
 - **`worktree remove` keeps the branch** - it removes the git worktree, its directory, the workspace, and all that workspace's tabs/agents, but not the branch (`git branch -D` separately).
 - **`open` reattaches, `create` makes new branches** - `worktree open` opens a workspace on a worktree that *already exists* (errors `worktree_not_found` otherwise, **including** any worktree of a repo this session does not track); `worktree create --branch` only makes a *new* branch (errors if it exists). existing branch with no worktree -> `git worktree add` first, then `open` (only works for the home repo).
-- **one repo per herdr session** - `worktree create` ignores the CLI cwd and always builds in the session's home/launch repo (verified: invoking it with cwd set to a different repo still produced a home-repo worktree). there is no way to manage a second repo's worktrees from one session; launch a separate `herdr --session <name>` inside that repo - that *is* a second herder.
+- **one repo per herdr session** - `worktree create` ignores the CLI cwd and always builds in the session's home/launch repo (verified: invoking it with cwd set to a different repo still produced a home-repo worktree). there is no way to manage a second repo's worktrees from one session; launch a separate `herdr --session <name>` inside that repo - that *is* a second session.
+- **`worktree create`/`open` run from the repo's main-checkout workspace** - invoked from inside a linked worktree they error `linked_worktree_source` ("new and open worktree actions start from the repo parent workspace"). pass `--workspace <main-checkout-ws>` (or run from there); the CLI cwd does not select the source workspace, the flag does.
 - **detect before `agent rename`** - a model launched with `pane run` is only renameable once herdr detects it. `herdr wait agent-status <pane> --status idle` first, or the rename misses the target.
 - **decorated labels are manual** - `sly ◆` style labels are set with `tab rename`, not auto-derived. renaming the handle does not update the tab label; re-`tab rename` to keep them in sync.
 - **`agent start` needs both `--cwd` and `--workspace`** - the ad-hoc escape hatch (vs the default `pane run` in a tab) takes `--cwd <worktree-path>` for the working dir (the cwd association `agent list` uses) and `--workspace <id>` for pane placement; they are independent. `--workspace` alone leaves the agent on *your* cwd, editing the wrong tree.

--- a/comitatus/skills/herdr/SKILL.md
+++ b/comitatus/skills/herdr/SKILL.md
@@ -21,7 +21,7 @@ herdr nests like this: **repo -> worktree -> workspace -> tab -> pane -> agent**
 - **pane** - a real terminal split. runs a shell, an agent, a server, anything.
 - **agent** - a coding agent (claude, codex, opencode, ...) running in a pane. each agent carries a **handle** in its `name` field (e.g. `fox`, `ivy`). you address agents by handle.
 - **herd** - a *group of agents you treat as a team*: 1..n members, models mixed freely (claude, codex, opencode/local, ...). a herd is a **logical roster, not a herdr object** - there is no `herd` command and no herd field on anything; it is **orthogonal** to the worktree->...->agent nesting above. a herd can run on a worktree, on the main checkout (a plain branch), or at any cwd; and a worktree can exist with **no** herd at all. members know the roster and message each other - and members of *other* herds - by handle (see the from/to protocol). "assigning a herd to work" just means launching its agents with their `cwd` at that work (a worktree dir or a branch checkout).
-- **herder / shepherd** - the top-level orchestrator (a workspace; you, reading this, are one) that spins up and tends herds. **exactly one per herdr session** - it is the session's home repo (the single main-checkout anchor every worktree-herd nests under). a second repo means a second herdr session, i.e. a second herder; you cannot manage two repos from one session (`worktree create` always targets the home repo). herder, herd, and member all get their names from a pooled convention with no herdr enforcement - see `## naming` below.
+- **herder** - the top-level orchestrator (a workspace; you, reading this, are one) that spins up and tends herds. **exactly one per herdr session** - it is the session's home repo (the single main-checkout anchor every worktree-herd nests under). a second repo means a second herdr session, i.e. a second herder; you cannot manage two repos from one session (`worktree create` always targets the home repo). herder and herd are **labeled descriptively** (by repo and by task); only member handles come from a name pool - all convention, no herdr enforcement - see `## naming` below.
 
 three facts that drive most workflows:
 
@@ -33,23 +33,27 @@ three facts that drive most workflows:
 
 ids are short: workspace `w8`, tab `w8:t1`, pane `w8:p1`. they are opaque and **not durable** - they can change as things open and close. never reuse an old id; re-read the current one from `worktree list`, `workspace list`, `agent list`, or a create/start response. most commands print json, so parse ids out of the json rather than guessing.
 
-## naming (shepherd -> herd -> members)
+## naming (repo -> task -> members)
 
-a convention layered on top of herdr - herdr stores **none** of it. three tiers, each named from a pool in [reference/names.md](reference/names.md), each name claimed as the **next unused** entry (read live state, skip taken):
+a convention layered on top of herdr - herdr stores **none** of it. three tiers; the first two are **labeled descriptively** (after what they are / do), the third draws a call-sign from a pool in [reference/names.md](reference/names.md):
 
-- **herder** - the top-level orchestrator workspace, **one per herdr session** (the home repo's main checkout; a second repo = a second session = a second herder). label it with a herder role name - `shepherd`, `drover`, `wrangler`, ... - via `workspace rename <ws> "<herder>"`.
-- **herd** - a managed group of agents. label its workspace with a collective noun - `flock`, `pack`, `troop`, ... - unique among live herd workspaces.
-- **member** - an agent in a herd. its **handle** is a short call-sign - `tim`, `jay`, `sly`, ... - set with `agent rename <pane> <handle>`.
+- **herder** - the top-level orchestrator workspace, **one per herdr session** (the home repo's main checkout; a second repo = a second session = a second herder). label it with a short **repo tag** - `claude-dom`, ... - via `workspace rename <ws> "<repo-tag>"`.
+- **herd** - a managed group of agents. label its workspace with a short **task tag** that says what the group is doing - `comitatus`, `terraform`, ... - derived from the branch, unique among live herd workspaces.
+- **member** - an agent in a herd. its **handle** is a short call-sign - `tim`, `jay`, `sly`, ... - claimed as the next unused pool entry, set with `agent rename <pane> <handle>`.
 
-**fully-qualified vs addressable.** a member's full identity is written `<herder>/<herd>/<member>` (e.g. `shepherd/flock/tim`) for humans and docs. but herdr has **no hierarchical addressing**: the only thing it stores or routes is the flat member handle, and you reach the agent with `agent send tim`. the `<herder>/` and `<herd>/` segments are operator bookkeeping (which herder owns which herd is convention, not herdr state), not part of the address.
+**why only members get pooled names.** a herd/herder label answers "what / where": the sidebar row is `<workspace> · <tab>` and the branch is **not** in it, so the workspace label is your only at-a-glance "what is this group doing" field - a task/repo tag spends it well, an arbitrary noun wastes it. a member handle is different: it is the **addressable identity** (`agent send tim`), so it must stay short, unique, phonetically distinct, and stable across a model relaunch - none of which a task name (many members per task) can be. so members draw from a pool; herds and herders are named after their work.
+
+**picking a task / repo tag.** a short, readable abbreviation of the branch (herd) or repo (herder) - judgment, not an algorithm: `chore/comitatus-fixes -> comitatus`, `chore/refactor-terraform -> terraform`, `issue/feature-3/add-socius -> socius`. keep it **<= ~10 chars** (see the labels rule) and unique among live herds; on a genuine collision qualify one (`tf-refac` / `api-refac`), though their repo groups already separate them in the sidebar.
+
+**fully-qualified vs addressable.** a member's full identity is written `<repo>/<task>/<member>` (e.g. `claude-domestique/comitatus/fox`) for humans and docs. but herdr has **no hierarchical addressing**: the only thing it stores or routes is the flat member handle, and you reach the agent with `agent send fox`. the `<repo>/` and `<task>/` segments are operator bookkeeping (which herder owns which herd is convention, not herdr state), not part of the address.
 
 rules that make it work:
 
 - **member handles are globally unique - herdr enforces it.** a duplicate `agent start` is rejected (`agent_name_taken`, verified), across *all* workspaces. claim each handle against live `agent list`; size the member pool above your peak concurrent agent count.
-- **labels <= ~10 chars.** rows render `<workspace> · <tab>`, so a long herder/herd label truncates the member's decorated tab label (a few collective nouns exceed this - flagged in names.md).
+- **labels <= ~10 chars.** rows render `<workspace> · <tab>`, so a long herder/herd label truncates the member's decorated tab label - abbreviate the task/repo tag to fit.
 - **handles are type-agnostic.** never encode the model in a handle; the tab already shows `◆ claude` / `◇ codex`, and a type-free handle survives relaunching a member on another model.
-- **names are stable, decoupled from the branch.** a herd keeps its name across reassignment to a new worktree/branch; the work is found via cwd, not the label.
-- **only home-repo worktrees nest under the herder.** a herd appears *under* the herder in the panel only when it's a linked worktree of the session's repo; plain workspaces and any other repo float separately (logical-only herds - the `<herder>/<herd>/...` path still names them, they just don't nest visually).
+- **labels track the work.** a herd's label follows its task: reassign the herd to a new branch and you **relabel** it to the new task tag (`workspace rename`). the work is still found via cwd, not the label - but the label is kept descriptive on purpose, so the sidebar always reads true.
+- **only home-repo worktrees nest under the herder.** a herd appears *under* the herder in the panel only when it's a linked worktree of the session's repo; plain workspaces and any other repo float separately (logical-only herds - the `<repo>/<task>/...` path still names them, they just don't nest visually).
 - **phonetic distinctness for members.** they message each other by handle in the from/to protocol and weak local models mis-type look-alikes - avoid rhyming clusters.
 
 ## discover state
@@ -219,7 +223,7 @@ git branch -D chore/review-x
 
 ### assign a herd to a worktree
 
-the common case: assign a herd to its own **worktree** (isolated branch + dir). that is just step 1 (create the worktree) then step 3 (attach each agent as a tab): agent 1 in the worktree's root tab, each additional agent in its own `tab create --workspace <ws> --cwd <wt>`. nothing extra - the herd is simply the agents you launched with that worktree's cwd. name the workspace with a **herd name** and each member with a **handle** from the pools (see `## naming`); the step-3 recipe's `workspace rename` / `tab rename` / `agent rename` are where those names land.
+the common case: assign a herd to its own **worktree** (isolated branch + dir). that is just step 1 (create the worktree) then step 3 (attach each agent as a tab): agent 1 in the worktree's root tab, each additional agent in its own `tab create --workspace <ws> --cwd <wt>`. nothing extra - the herd is simply the agents you launched with that worktree's cwd. name the workspace with a **task tag** and each member with a **handle** from the pool (see `## naming`); the step-3 recipe's `workspace rename` / `tab rename` / `agent rename` are where those names land.
 
 a herd does **not** require a worktree. launch one at any cwd - most usefully the **main checkout** (a plain branch): `herdr workspace create --cwd <repo>`, then attach agents there. caveat: a plain-branch herd shares the **single** repo checkout, so "reassign to a different branch" is a global `git checkout` with no isolation - prefer a worktree when you want a herd pinned to its own branch without disturbing other work.
 
@@ -331,7 +335,7 @@ herdr wait agent-status w9:p1 --status done --timeout 120000   # a sibling finis
 - **codex TUI paste gotcha** - a long `send-text` / `agent send` into a codex TUI may be ingested as a bracketed paste that a single Enter does not submit. keep protocol messages one line and short. if you deliberately send a long codex message and silence follows, send one extra Enter or retry as shorter one-line chunks.
 - **opencode status needs the fix plugin** - herdr 0.7.0's managed opencode integration is out of date with opencode 1.17.8 (object-form `session.status` + fire-and-forget idle), so opencode agents get stuck `working` / never report state right. the sibling plugin `~/.config/opencode/plugins/herdr-opencode-status-fix.js` restores correct working/idle/blocked reporting. without it, `wait agent-status` on an opencode pane is unreliable.
 - **only the home repo's worktree tree nests; plain workspaces don't** - the sidebar nests exactly one repo group (main checkout -> its linked worktrees -> tabs), keyed on `repo_root`. a `workspace create --cwd` workspace gets **no** repo association and floats ungrouped, even at a repo root. give each agent in a herd a *tab* in the herd's one workspace; make the herd a worktree if you want it to nest under the herder.
-- **keep the workspace label short** - agent rows render as `<workspace> · <tab>`, so a long workspace label truncates the decorated tab label.
+- **keep the workspace label short** - agent rows render as `<workspace> · <tab>`, so a long workspace label truncates the decorated tab label; keep the task/repo tag <= ~10 chars.
 - **`worktree remove` keeps the branch** - it removes the git worktree, its directory, the workspace, and all that workspace's tabs/agents, but not the branch (`git branch -D` separately).
 - **`open` reattaches, `create` makes new branches** - `worktree open` opens a workspace on a worktree that *already exists* (errors `worktree_not_found` otherwise, **including** any worktree of a repo this session does not track); `worktree create --branch` only makes a *new* branch (errors if it exists). existing branch with no worktree -> `git worktree add` first, then `open` (only works for the home repo).
 - **one repo per herdr session** - `worktree create` ignores the CLI cwd and always builds in the session's home/launch repo (verified: invoking it with cwd set to a different repo still produced a home-repo worktree). there is no way to manage a second repo's worktrees from one session; launch a separate `herdr --session <name>` inside that repo - that *is* a second herder.

--- a/comitatus/skills/herdr/reference/cli.md
+++ b/comitatus/skills/herdr/reference/cli.md
@@ -95,9 +95,10 @@ model launch argv:
 
 decorated tab-label glyphs (from the legacy spawn convention): claude `◆`, codex `◇`,
 opencode `⬨`. format is `<handle> <glyph>`, set with `tab rename` (the glyph already encodes
-the type). rows render as `<workspace> · <tab>`, and the workspace label is a herd's full
-worktree name (or a herder's short repo tag), so a long worktree name truncates the tab
-label in the collapsed sidebar - the handle reappears on focus/widen.
+the type). rows render as `<workspace> · <tab>`, and herdr labels the workspace by default (a
+worktree's directory name, or a main checkout's repo name) - you don't rename it - so a long
+worktree name truncates the tab label in the collapsed sidebar; the handle reappears on
+focus/widen.
 
 json fields (`agent list` -> `result.agents[]`): `name` (handle), `agent` (integration type:
 claude/codex/opencode/...), `agent_status`, `cwd`, `foreground_cwd`, `workspace_id`, `tab_id`,

--- a/comitatus/skills/herdr/reference/cli.md
+++ b/comitatus/skills/herdr/reference/cli.md
@@ -94,8 +94,10 @@ model launch argv:
   (`opencode models` lists ids; format is `provider/model`.)
 
 decorated tab-label glyphs (from the legacy spawn convention): claude `◆`, codex `◇`,
-opencode `⬨`. format is `<handle> <glyph> <agent-type>`, set with `tab rename`. keep the
-workspace label short - rows render as `<workspace> · <tab>`.
+opencode `⬨`. format is `<handle> <glyph>`, set with `tab rename` (the glyph already encodes
+the type). rows render as `<workspace> · <tab>`, and the workspace label is a herd's full
+worktree name (or a herder's short repo tag), so a long worktree name truncates the tab
+label in the collapsed sidebar - the handle reappears on focus/widen.
 
 json fields (`agent list` -> `result.agents[]`): `name` (handle), `agent` (integration type:
 claude/codex/opencode/...), `agent_status`, `cwd`, `foreground_cwd`, `workspace_id`, `tab_id`,

--- a/comitatus/skills/herdr/reference/names.md
+++ b/comitatus/skills/herdr/reference/names.md
@@ -1,30 +1,36 @@
 # herd naming
 
 the **member** tier draws its call-signs from a pool (below). the **herder** and **herd**
-tiers are *not* pooled - they are labeled descriptively (a short **repo tag** and a short
-**task tag**); see the `## naming` section of [SKILL.md](../SKILL.md). this file holds the
-member pool plus the rules for picking the descriptive tags.
+tiers are *not* pooled - they are labeled descriptively (a herder by a short **repo tag**, a
+herd by its **worktree name**); see the `## naming` section of [SKILL.md](../SKILL.md). this
+file holds the member pool plus the rules for the descriptive labels.
 
-## task / repo tags (herd + herder labels)
+## worktree names + repo tags (herd + herder labels)
 
-not a pool - a short, readable abbreviation of the branch (herd) or repo (herder), chosen
-by judgment, not an algorithm:
+not a pool:
+
+- a **herd** is labeled with its **worktree directory name** verbatim - the basename of
+  `~/.herdr/worktrees/<repo>/<branch-slug>`. (a herd not on a worktree gets a short
+  descriptive tag instead.)
+- a **herder** is labeled with a short **repo tag** - a ~10-char abbreviation of the repo.
 
 ```
-chore/comitatus-fixes        -> comitatus
-chore/refactor-terraform     -> terraform
-issue/feature-3/add-socius   -> socius
-repo claude-domestique       -> claude-dom
+chore/comitatus-fixes      (worktree) -> chore-comitatus-fixes
+chore/refactor-terraform   (worktree) -> chore-refactor-terraform
+repo claude-domestique     (herder)   -> claude-dom
 ```
 
 rules:
 
-- **<= ~10 chars.** agent rows render `<workspace> · <tab>`, so a longer label truncates the
-  member's decorated tab label. abbreviate to fit.
-- **unique among live herds.** on a genuine collision, qualify one (`tf-refac` / `api-refac`);
-  repo groups already separate them visually.
-- **descriptive, not stable.** the label follows the work - relabel when you reassign a herd
-  to a new branch.
+- **a worktree name is long and truncates the tab label.** agent rows render
+  `<workspace> · <tab>`, so a full worktree name pushes the member's decorated
+  `<handle> <glyph>` tab label off the collapsed sidebar - the handle reappears on
+  focus/widen. that is the accepted trade for an unambiguous label; keep the **herder** repo
+  tag short (~10) so its own row stays readable.
+- **unique among live workspaces.** two worktrees rarely share a basename; if they do, the
+  paths differ - qualify the label.
+- **descriptive, not stable.** the label follows the worktree - relabel when you reassign a
+  herd to a new worktree.
 
 check live labels before reusing one:
 

--- a/comitatus/skills/herdr/reference/names.md
+++ b/comitatus/skills/herdr/reference/names.md
@@ -1,47 +1,54 @@
-# herd naming pools
+# herd naming
 
-names for the **shepherd -> herd -> members** taxonomy (see the `## naming` section of [SKILL.md](../SKILL.md)). each name is a herdr **workspace label** (herder, herd) or a **member handle**, claimed as the *next unused* entry from its pool - check live state and skip any already in use:
+the **member** tier draws its call-signs from a pool (below). the **herder** and **herd**
+tiers are *not* pooled - they are labeled descriptively (a short **repo tag** and a short
+**task tag**); see the `## naming` section of [SKILL.md](../SKILL.md). this file holds the
+member pool plus the rules for picking the descriptive tags.
+
+## task / repo tags (herd + herder labels)
+
+not a pool - a short, readable abbreviation of the branch (herd) or repo (herder), chosen
+by judgment, not an algorithm:
+
+```
+chore/comitatus-fixes        -> comitatus
+chore/refactor-terraform     -> terraform
+issue/feature-3/add-socius   -> socius
+repo claude-domestique       -> claude-dom
+```
+
+rules:
+
+- **<= ~10 chars.** agent rows render `<workspace> · <tab>`, so a longer label truncates the
+  member's decorated tab label. abbreviate to fit.
+- **unique among live herds.** on a genuine collision, qualify one (`tf-refac` / `api-refac`);
+  repo groups already separate them visually.
+- **descriptive, not stable.** the label follows the work - relabel when you reassign a herd
+  to a new branch.
+
+check live labels before reusing one:
 
 ```bash
-herdr workspace list | python3 -c 'import sys,json;print(sorted(w.get("label") for w in json.load(sys.stdin)["result"]["workspaces"]))'   # taken herder/herd labels  # (label list; helper covers handles)
-herdr agent list     | node "$H" members  # taken member handles
+herdr workspace list | python3 -c 'import sys,json;print(sorted(w.get("label") for w in json.load(sys.stdin)["result"]["workspaces"]))'   # taken workspace labels
+```
+
+## members - individual agents
+
+short, phonetically distinct call-signs, type-agnostic, each claimed as the **next unused**
+entry - check live state and skip any already in use:
+
+```bash
+herdr agent list | node "$H" members  # taken member handles
 ```
 
 constraints:
 
-- **labels <= ~10 chars.** agent rows render `<workspace> · <tab>`, so a longer herder/herd label truncates the member's decorated tab label.
-- **member handles are globally unique - herdr enforces it.** a duplicate `agent start` is rejected with `agent_name_taken` (verified). the member pool must comfortably exceed your peak concurrent agent count, or the shepherd runs out of names.
+- **member handles are globally unique - herdr enforces it.** a duplicate `agent start` is
+  rejected with `agent_name_taken` (verified). the pool must comfortably exceed your peak
+  concurrent agent count.
 - **type-agnostic handles.** never encode the model in a handle; the tab already shows the glyph.
-
-## herders - top-level orchestrators
-
-role names for the single top-level orchestrator per herdr session (a second repo = a second session = a second herder). `herder` itself is omitted (it collides with the product name *herdr*).
-
-```
-shepherd  drover    wrangler  mahout    falconer  rancher   grazier
-stockman  herdsman  cowhand   cowboy    gaucho    vaquero   buckaroo
-goatherd  swineherd cameleer  muleteer  teamster  wagoner   ostler
-apiarist  beekeeper houndsman warden    keeper    handler   nomad
-```
-
-## herds - managed groups
-
-collective nouns (deduped from the curated list). all <= 10 chars.
-
-```
-colony, troop, flutter, caravan, clowder, army, quiver, murder, pack, drove,
-soar, parade, mob, business, school, stand, skulk, leash, gaggle, flock, tower,
-cloud, horde, charm, cast, kettle, bloat, thunder, team, cackle, conspiracy,
-mischief, passel, romp, raft, parliament, prickle, gaze, den, pit, unkindness,
-stench, bed, scurry, fever, bevy, ambush, streak, dazzle, zeal
-```
-
-- **too long (>10 chars - will truncate the tab label; use only if you accept that):** `congregation`, `kaleidoscope`, `convocation`, `flamboyance`, `ostentation`
-- **negative connotation (keep or drop consciously if a label ever faces anyone but you):** `murder`, `unkindness`, `conspiracy`, `stench`, `cackle`, `mischief`
-
-## members - individual agents
-
-short, phonetically distinct call-signs. type-agnostic. avoid rhyming clusters - members address each other by handle in the from/to protocol, and weak local models mis-type look-alikes.
+- **phonetic distinctness.** members address each other by handle in the from/to protocol, and
+  weak local models mis-type look-alikes - avoid rhyming clusters.
 
 ```
 tim   jay   sly   gus   mae   ned   kit   pip   rex   ada
@@ -49,7 +56,8 @@ hal   val   wes   zed   sol   ren   lou   dot   cleo  otis
 bea   fitz  hank  jules nico  quinn tess  vlad  wren  zane
 ```
 
-for maximum distinctness over flavor, use the NATO phonetic set instead (each word is deliberately unconfusable over a noisy channel):
+for maximum distinctness over flavor, use the NATO phonetic set instead (each word is
+deliberately unconfusable over a noisy channel):
 
 ```
 alfa bravo charlie delta echo foxtrot golf hotel india juliet

--- a/comitatus/skills/herdr/reference/names.md
+++ b/comitatus/skills/herdr/reference/names.md
@@ -1,42 +1,16 @@
 # herd naming
 
-the **member** tier draws its call-signs from a pool (below). the **herder** and **herd**
-tiers are *not* pooled - they are labeled descriptively (a herder by a short **repo tag**, a
-herd by its **worktree name**); see the `## naming` section of [SKILL.md](../SKILL.md). this
-file holds the member pool plus the rules for the descriptive labels.
+the **only** name you assign is the **member handle** - a call-sign from the pool below, set
+with `agent rename`. everything else is left at herdr's default:
 
-## worktree names + repo tags (herd + herder labels)
+- a **worktree's workspace** is auto-labeled by herdr with the **worktree directory name**
+  (`chore-comitatus-fixes`); a **repo's main checkout** with the **repo name**
+  (`claude-domestique`). you never rename either - see the `## naming` section of
+  [SKILL.md](../SKILL.md).
+- the decorated **tab** label `<handle> <glyph>` (`fox ◆`) is the one other thing you set, via
+  `tab rename`; it is not pooled either.
 
-not a pool:
-
-- a **herd** is labeled with its **worktree directory name** verbatim - the basename of
-  `~/.herdr/worktrees/<repo>/<branch-slug>`. (a herd not on a worktree gets a short
-  descriptive tag instead.)
-- a **herder** is labeled with a short **repo tag** - a ~10-char abbreviation of the repo.
-
-```
-chore/comitatus-fixes      (worktree) -> chore-comitatus-fixes
-chore/refactor-terraform   (worktree) -> chore-refactor-terraform
-repo claude-domestique     (herder)   -> claude-dom
-```
-
-rules:
-
-- **a worktree name is long and truncates the tab label.** agent rows render
-  `<workspace> · <tab>`, so a full worktree name pushes the member's decorated
-  `<handle> <glyph>` tab label off the collapsed sidebar - the handle reappears on
-  focus/widen. that is the accepted trade for an unambiguous label; keep the **herder** repo
-  tag short (~10) so its own row stays readable.
-- **unique among live workspaces.** two worktrees rarely share a basename; if they do, the
-  paths differ - qualify the label.
-- **descriptive, not stable.** the label follows the worktree - relabel when you reassign a
-  herd to a new worktree.
-
-check live labels before reusing one:
-
-```bash
-herdr workspace list | python3 -c 'import sys,json;print(sorted(w.get("label") for w in json.load(sys.stdin)["result"]["workspaces"]))'   # taken workspace labels
-```
+so this file is just the member call-sign pool.
 
 ## members - individual agents
 

--- a/docs/superpowers/specs/2026-06-22-herd-naming-design.md
+++ b/docs/superpowers/specs/2026-06-22-herd-naming-design.md
@@ -64,3 +64,20 @@ label convention changes — **no code, hook, or test changes**.
   workspace label is its natural home, the tab label already carries `<handle> <glyph> <type>`.
 - **Composite `task+team` labels** (`cmt·pack`) — the ~10-char budget makes them cryptic.
 - **Mechanical truncation of the branch** — produces ugly tails (`comitatus-`).
+
+## Revision — 2026-06-22 (same day, after a live trial)
+
+Exercising the convention in a live herdr session surfaced two refinements, now the accepted
+scheme:
+
+- **Subordinate (linked) worktree workspace → the full worktree directory name**
+  (`chore-comitatus-fixes`), *not* a short ≤10-char task tag. Rationale: the label should name
+  the worktree unambiguously. Accepted cost: the long label truncates the decorated tab label
+  in the collapsed sidebar (the handle reappears when the workspace is focused/widened). The
+  **herder** workspace still uses a short repo tag (`claude-dom`).
+- **Agent tab label → `<handle> <glyph>`** (`fox ◆`), dropping the `<type>` word — the glyph
+  already encodes the model, so the type was redundant.
+
+Member handles (call-signs) and the "descriptive, not pooled" principle are unchanged. This
+revision is reconciled into `SKILL.md` (`## naming`, recipes, gotchas), `reference/cli.md`,
+and `reference/names.md`; comitatus bumped 0.1.1 → 0.1.2.

--- a/docs/superpowers/specs/2026-06-22-herd-naming-design.md
+++ b/docs/superpowers/specs/2026-06-22-herd-naming-design.md
@@ -1,0 +1,66 @@
+# Herd naming: descriptive labels over collective nouns
+
+- **Date:** 2026-06-22
+- **Status:** Accepted
+- **Plugin:** comitatus (`skills/herdr`)
+
+## Problem
+
+herdr renders each agent row as `<workspace> · <tab>` (e.g. `pack · fox ◆ claude`).
+The branch/worktree is **not** shown in the row, so the **workspace label is the only
+"what is this group doing" field**. The prior convention spent that field on an opaque
+collective noun (`pack`, `flock`, …) claimed from a pool, and documented it as
+"stable, decoupled from the branch." Result: scanning the sidebar you cannot tell which
+herd is doing what.
+
+## Decision
+
+Label workspaces **descriptively**, by what they are / what they do:
+
+| Tier | Labeled thing | Old | New |
+|------|---------------|-----|-----|
+| herder (orchestrator = repo main checkout) | workspace label | role-name pool (`shepherd`…) | **repo tag** (≤~10 chars), e.g. `claude-dom` |
+| herd (worktree / task) | workspace label | collective-noun pool (`pack`…) | **task tag** (≤~10 chars), e.g. `comitatus` |
+| member (agent) | handle | call-sign pool | **call-sign** (unchanged), e.g. `fox` |
+
+- Task/repo tags are **short, hand-picked, readable** abbreviations of the branch/repo —
+  judgment, not an algorithm. Keep them ≤~10 chars or they truncate the member's
+  decorated tab label. Unique among live herds; qualify on a genuine collision.
+- Member handles stay arbitrary call-signs: a handle is the addressable identity
+  (`agent send fox`) and must stay short, unique, phonetically distinct, and stable across
+  a model relaunch — so it cannot be task-derived (a task has many members).
+- The fully-qualified path notation becomes `<repo>/<task>/<member>`
+  (e.g. `claude-domestique/comitatus/fox`), which reads better than `shepherd/pack/fox`.
+
+## Consequence (an intended reversal)
+
+The label now **couples** to the task — that coupling is the point. Reassigning a herd to a
+new branch means **relabeling** it (`workspace rename` to the new task tag); the existing
+"reassign a herd" flow already calls `workspace rename`, so this is a guidance change, not a
+new step. We drop the old "names are stable, decoupled from the branch" rule.
+
+## Mechanics unchanged
+
+herdr stores none of this convention. Herds are still "agents sharing a `workspace_id`";
+roster sync still keys on `workspace_id`; worktree association is still by `cwd`. Only the
+label convention changes — **no code, hook, or test changes**.
+
+## Scope of change
+
+- `skills/herdr/SKILL.md`: rewrite `## naming`; update the herd/herder framing in
+  `## concepts`, the "assign / reassign a herd" guidance, and the "keep the workspace label
+  short" gotcha.
+- `skills/herdr/reference/names.md`: delete the herder and herd pools; keep the member
+  call-sign pool; add task-tag / repo-tag guidance.
+- `node scripts/bump-version.js comitatus patch` before merge.
+- **Live application (done):** relabel the running session's herds — `pack → comitatus`,
+  `flock → terraform`, herder `claude-domestique → claude-dom`.
+
+## Alternatives rejected
+
+- **Surface the task via herdr's worktree grouping** instead of the label — the agent row
+  never shows the branch, so the label is the only lever.
+- **Put the task in the tab label** — the task is per-herd (shared across its tabs); the
+  workspace label is its natural home, the tab label already carries `<handle> <glyph> <type>`.
+- **Composite `task+team` labels** (`cmt·pack`) — the ~10-char budget makes them cryptic.
+- **Mechanical truncation of the branch** — produces ugly tails (`comitatus-`).

--- a/docs/superpowers/specs/2026-06-22-herd-naming-design.md
+++ b/docs/superpowers/specs/2026-06-22-herd-naming-design.md
@@ -81,3 +81,25 @@ scheme:
 Member handles (call-signs) and the "descriptive, not pooled" principle are unchanged. This
 revision is reconciled into `SKILL.md` (`## naming`, recipes, gotchas), `reference/cli.md`,
 and `reference/names.md`; comitatus bumped 0.1.1 → 0.1.2.
+
+## Revision 2 — 2026-06-22 (same day): drop the herder tier and all label renaming
+
+A further live finding collapsed the convention to its minimum: **herdr already labels a new
+worktree's workspace with the worktree directory name by default** (verified with a throwaway
+worktree), and a repo's main checkout with the repo name. So *no `workspace rename` and no
+`worktree create --label` are needed at all* — the defaults already are the convention.
+
+Accordingly:
+
+- **The "herder" naming tier is removed.** The repo's main checkout is just that; it keeps
+  herdr's default label (the repo name) and is never renamed. The coined term "herder" is
+  dropped from the skill in favour of plain "main checkout / home repo".
+- **No workspace or worktree renaming.** Recipes drop the `workspace rename` step and the
+  `worktree create --label` flag; herds rely on herdr's default worktree-name label.
+- **What you still assign:** only the **member handle** (`agent rename`, needed for
+  `agent send`) and the decorated **tab** label `<handle> <glyph>` (`tab rename`).
+- New gotcha recorded: `worktree create`/`open` must run from the repo's main-checkout
+  workspace (`--workspace <main>`), else `linked_worktree_source`.
+
+Reconciled across `SKILL.md` (`## naming`, `## concepts`, recipes, gotchas),
+`reference/cli.md`, and `reference/names.md`; comitatus bumped 0.1.2 → 0.1.3.


### PR DESCRIPTION
## What

Reworks the `comitatus` herdr skill's naming convention. herdr renders each sidebar row as `<workspace> · <tab>`, and **herdr already labels workspaces sensibly by default** — so the convention collapses to "leave the defaults; assign only what herdr can't derive."

**You assign exactly two things; everything else is a herdr default you never rename:**

| Thing | Source | Example |
|-------|--------|---------|
| member **handle** | you (`agent rename`) — it's the `agent send` address | `fox` |
| agent **tab label** | you (`tab rename`) — `<handle> <glyph>` | `fox ◆` |
| worktree **workspace label** | **herdr default** = worktree dir name | `chore-comitatus-fixes` |
| main-checkout **workspace label** | **herdr default** = repo name | `claude-domestique` |

Sidebar row = `<worktree-name> · <handle> <glyph>` — reads true with **zero renaming**.

### How it got here (the commits)
1. Replaced opaque collective nouns (`pack`/`flock`) with descriptive labels.
2. Switched herd labels to the full worktree name; agent tab label to `<handle> <glyph>`.
3. **This rev:** a live probe proved herdr *already* defaults a worktree's workspace label to the worktree dir name (and a main checkout's to the repo name) — so the `workspace rename` step and `worktree create --label` were unnecessary. **Removed the "herder" naming tier entirely** and all workspace/worktree renaming.

## Changes
- `skills/herdr/SKILL.md` — `## naming` rewritten (`worktree -> members`); the `## concepts` "herder" entry replaced with plain "home repo / main checkout"; recipes drop `workspace rename` + `worktree create --label`; gotchas updated; added the `linked_worktree_source` gotcha (worktree create/open must run from the main-checkout workspace).
- `skills/herdr/reference/cli.md`, `reference/names.md` — reconciled; `names.md` reduced to just the member call-sign pool.
- `docs/superpowers/specs/2026-06-22-herd-naming-design.md` — design record + two same-day revision notes.
- Bumped `comitatus` 0.1.0 → **0.1.3**.

## Verification
- Pure markdown — **no code touched; 25/25 tests pass**.
- Grep confirms no `herder` / `task tag` / `<type>` / collective-noun references remain.
- Live herdr session matches: main checkouts show repo names, worktrees show dir names, agents show `fox ◆` / `sly ◆` / `jay ◇` — all herdr defaults except the tab glyphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)