### PR TITLE
chore - add stilus writing plugin with orchestrated review phase

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -33,6 +33,12 @@
       "source": "./comitatus",
       "description": "herdr workflows - packages the herdr agent-orchestration skill for claude and codex, auto-injected inside herdr",
       "version": "0.4.0"
+    },
+    {
+      "name": "stilus",
+      "source": "./stilus",
+      "description": "Adaptive writing pipeline - draft in a project's voice, then remove AI slop via write/edit/revise/review phases",
+      "version": "0.1.0"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -37,7 +37,7 @@
     {
       "name": "stilus",
       "source": "./stilus",
-      "description": "Adaptive writing pipeline - draft in a project's voice, then remove AI slop via write/edit/revise/review phases",
+      "description": "Writing tools - remove AI slop with deslop, write in a project's voice, and review finished prose (correctness, graded slop, human and AI perception) via /stilus:review",
       "version": "0.1.0"
     }
   ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,7 @@ Each plugin owns specific context domains. When adding or modifying context, res
 | **memento** | Session management | `rules/sessions.md` |
 | **onus** | Git operations, work items | `rules/git.md`, `rules/work-items.md` |
 | **comitatus** | herdr orchestration | `skills/herdr/SKILL.md` |
+| **stilus** | Prose drafting, editing, and review | `agents/deslop.md` (slop catalog), `rules/voice.md` (voice schema), `context/reviewing.md` (review flow + scoring), `agents/review-correctness.md`, `agents/review-voice.md`, `agents/review-summary.md` |
 
 **Ownership rules:**
 - Single source of truth: each concept defined in exactly one place

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-**IMPORTANT: Before completing work on any branch that modifies plugin files (mantra/, memento/, onus/, agent-artifex/, comitatus/), run `node scripts/bump-version.js <plugin> <patch|minor|major>` for each affected plugin. Do not merge without bumping.**
+**IMPORTANT: Before completing work on any branch that modifies plugin files (mantra/, memento/, onus/, agent-artifex/, comitatus/, stilus/), run `node scripts/bump-version.js <plugin> <patch|minor|major>` for each affected plugin. Do not merge without bumping.**
 
 ## Meta Note: Self-Referential Project
 
@@ -34,7 +34,9 @@ claude-domestique/
 ├── mantra/                  # Context refresh plugin
 ├── memento/                 # Session persistence plugin
 ├── onus/                    # Work item automation plugin
-└── comitatus/                  # herdr workflows plugin
+├── comitatus/               # herdr workflows plugin
+├── agent-artifex/           # AI design & testing guidance plugin
+└── stilus/                  # Writing tools plugin
 ```
 
 Each plugin follows the same structure:

--- a/docs/superpowers/plans/2026-06-18-stilus-writing-plugin.md
+++ b/docs/superpowers/plans/2026-06-18-stilus-writing-plugin.md
@@ -1,0 +1,732 @@
+# Stilus Writing Plugin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a new `stilus` plugin to the claude-domestique marketplace that drafts prose in a project's voice and then removes AI slop, via an adaptive write/edit/revise/review pipeline.
+
+**Architecture:** A skill-and-agent plugin (no JS hooks). The `write` skill is the on-demand orchestrator: it resolves a voice profile (project → user → plugin base), drafts in that voice, then dispatches three subagents — `deslop` (subtractive edit), `reviser` (adjudicate + restructure), `reviewer` (read-only judge) — escalating depth by the piece's stakes. deslop is the existing agent, shipped as-is, and is the single source of truth for the slop catalog; every other phase references it rather than restating it.
+
+**Tech Stack:** Markdown prompt files (agents, skill, rules, context), JSON manifests (`plugin.json`, `package.json`, `marketplace.json`). Node only for the version/validation scripts already in the repo. No test framework — like agent-artifex, this plugin is pure prompts/config; verification is JSON validity plus structural/frontmatter checks plus a manual smoke test.
+
+## Global Constraints
+
+- **Initial version: `0.1.0`**, seeded in `stilus/package.json` and `.claude-plugin/marketplace.json`. `stilus/.claude-plugin/plugin.json` carries **no** version field (version is maintained at the marketplace/package level only).
+- **No JS tests.** This plugin ships no Jest suite (agent-artifex precedent). Verification is inline commands, not committed tests.
+- **deslop ships essentially as-is.** Copy the existing agent verbatim. The orchestrator never invokes its standalone drafting path.
+- **On-demand only.** No hooks, no SessionStart/UserPromptSubmit injection, no global context.
+- **Cross-reference, never restate.** The subtractive catalog + shared craft (lead with the point, sentence rhythm, accuracy over precision) live in `deslop`. The voice base, reviser, reviewer, and any project voice profile reference these; they do not restate them.
+- **Voice scan order:** project `.claude/rules/voice.md` → user `~/.claude/rules/voice.md` → plugin `rules/voice.md` base. Higher tier overrides lower per section.
+- **Commit format:** `chore - <lowercase description>`, HEREDOC, no attribution, no emojis (repo convention). Work happens on branch `chore/add-stilus-plugin` (already created).
+- **Out of scope:** migrating the personal `writing` skill into a voice profile; optional `/stilus:deslop` and `/stilus:review` commands; fixing agent-artifex's missing package.json.
+
+## File Structure
+
+Files created/modified, each with one responsibility:
+
+- `stilus/.claude-plugin/plugin.json` — plugin manifest (name, description, author, keywords). No version.
+- `stilus/package.json` — version source of truth for `bump-version.js`. No deps, no tests.
+- `stilus/README.md` — what the plugin is and how to use it.
+- `stilus/agents/deslop.md` — Edit phase. Subtractive. Owns the slop catalog (copied verbatim from the source agent).
+- `stilus/agents/reviser.md` — Revise phase. Adjudicates deslop's cuts and fixes structure.
+- `stilus/agents/reviewer.md` — Review phase. Independent, read-only judge.
+- `stilus/skills/write/SKILL.md` — Write phase + adaptive orchestrator. Entry point.
+- `stilus/rules/voice.md` — Generic voice base: profile schema + neutral defaults.
+- `stilus/context/authoring-a-voice.md` — Companion: how to author a project voice profile.
+- `.claude-plugin/marketplace.json` — add the `stilus` entry (modify).
+- `scripts/bump-version.js` — add `'stilus'` to the `PLUGINS` array (modify, line 16).
+- `CLAUDE.md` — version-bump note, repo-structure tree, Context Ownership table (modify).
+
+Task order: 1 (scaffold + registration) → 2 (deslop) → 3 (voice base + companion) → 4 (reviser) → 5 (reviewer) → 6 (orchestrator skill) → 7 (docs + final validation). Task 6 references the outputs of 2–5, so it comes after them.
+
+---
+
+### Task 1: Plugin scaffold, manifest, and marketplace registration
+
+**Files:**
+- Create: `stilus/.claude-plugin/plugin.json`
+- Create: `stilus/package.json`
+- Create: `stilus/README.md`
+- Modify: `.claude-plugin/marketplace.json` (add `stilus` entry after `agent-artifex`)
+- Modify: `scripts/bump-version.js:16` (add `'stilus'` to `PLUGINS`)
+
+**Interfaces:**
+- Produces: a registered plugin named `stilus` at source `./stilus`, version `0.1.0`, bumpable via `node scripts/bump-version.js stilus <type>`.
+
+- [ ] **Step 1: Create `stilus/.claude-plugin/plugin.json`**
+
+````json
+{
+  "name": "stilus",
+  "description": "Stilus — adaptive writing pipeline: draft in a project's voice, then remove AI slop. Write, edit, revise, and review prose with deslop as the subtractive base and a project-supplied voice layer.",
+  "author": {
+    "name": "Flexion"
+  },
+  "repository": "https://github.com/flexion/claude-domestique",
+  "homepage": "https://github.com/flexion/claude-domestique",
+  "license": "MIT",
+  "keywords": [
+    "writing",
+    "editing",
+    "prose",
+    "voice",
+    "deslop",
+    "flexion"
+  ]
+}
+````
+
+- [ ] **Step 2: Create `stilus/package.json`**
+
+````json
+{
+  "name": "stilus",
+  "version": "0.1.0",
+  "description": "Stilus — adaptive writing pipeline (write/edit/revise/review) with deslop as the subtractive base",
+  "private": true,
+  "license": "MIT"
+}
+````
+
+- [ ] **Step 3: Create `stilus/README.md`**
+
+````markdown
+# stilus
+
+Adaptive writing pipeline for Claude Code. Draft prose in a project's voice, then remove AI slop.
+
+Latin for the writing instrument and the root of "style."
+
+## What it does
+
+`stilus` runs prose through up to four phases, escalating depth to match what a piece is worth:
+
+1. **Write** — draft in the project's voice (additive).
+2. **Edit** — remove slop line by line with the `deslop` agent (subtractive; changes how, never what).
+3. **Revise** — adjudicate deslop's cuts and fix structure so the piece leads with the point.
+4. **Review** — an independent, read-only judge checks fit, surviving tells, accuracy, and register.
+
+A Slack message gets write → edit. A document gets write → edit → revise. A white paper gets all four.
+
+## On-demand only
+
+`stilus` ships no hooks and injects no global context. The `write` skill triggers when you are drafting or editing prose to send or publish, and costs nothing otherwise.
+
+## Voice profiles
+
+`stilus` carries no personality. A project supplies its own voice in `.claude/rules/voice.md`:
+
+```yaml
+---
+extends: stilus/voice.md
+domain: voice
+---
+```
+
+Fill in the sections from `rules/voice.md`. A personal default can live at `~/.claude/rules/voice.md` and follows you across repos. Precedence: project over user over the plugin base. See `context/authoring-a-voice.md`.
+
+## Single source of truth
+
+The slop catalog and shared craft (lead with the point, sentence rhythm, accuracy over precision) live in the `deslop` agent. The voice layer, reviser, and reviewer reference them; they never restate them.
+````
+
+- [ ] **Step 4: Add the `stilus` entry to `.claude-plugin/marketplace.json`**
+
+Insert this object as the last element of the `plugins` array, after the `agent-artifex` entry (add a comma after the `agent-artifex` closing brace):
+
+````json
+    {
+      "name": "stilus",
+      "source": "./stilus",
+      "description": "Adaptive writing pipeline - draft in a project's voice, then remove AI slop via write/edit/revise/review phases",
+      "version": "0.1.0"
+    }
+````
+
+- [ ] **Step 5: Add `'stilus'` to the `PLUGINS` array in `scripts/bump-version.js`**
+
+Change line 16 from:
+
+````javascript
+const PLUGINS = ['mantra', 'memento', 'onus', 'agent-artifex'];
+````
+
+to:
+
+````javascript
+const PLUGINS = ['mantra', 'memento', 'onus', 'agent-artifex', 'stilus'];
+````
+
+- [ ] **Step 6: Verify all JSON is valid and the registration is consistent**
+
+Run:
+````bash
+node -e "JSON.parse(require('fs').readFileSync('stilus/.claude-plugin/plugin.json','utf8')); JSON.parse(require('fs').readFileSync('stilus/package.json','utf8')); const m=JSON.parse(require('fs').readFileSync('.claude-plugin/marketplace.json','utf8')); const e=m.plugins.find(p=>p.name==='stilus'); if(!e) throw new Error('stilus missing from marketplace'); if(e.version!=='0.1.0') throw new Error('version != 0.1.0'); if(e.source!=='./stilus') throw new Error('bad source'); console.log('OK: plugin.json, package.json, marketplace entry valid');"
+node -e "const s=require('fs').readFileSync('scripts/bump-version.js','utf8'); if(!/PLUGINS\s*=\s*\[[^\]]*'stilus'/.test(s)) throw new Error('stilus not in PLUGINS'); console.log('OK: stilus in bump-version PLUGINS');"
+````
+Expected: `OK: plugin.json, package.json, marketplace entry valid` then `OK: stilus in bump-version PLUGINS`.
+
+- [ ] **Step 7: Commit**
+
+````bash
+git add stilus/.claude-plugin/plugin.json stilus/package.json stilus/README.md .claude-plugin/marketplace.json scripts/bump-version.js
+git commit -m "$(cat <<'EOF'
+chore - scaffold stilus plugin and register in marketplace
+
+- add plugin.json, package.json, README
+- register stilus 0.1.0 in marketplace.json
+- add stilus to bump-version PLUGINS so it is bumpable
+EOF
+)"
+````
+
+---
+
+### Task 2: deslop agent (Edit phase)
+
+**Files:**
+- Create: `stilus/agents/deslop.md` (verbatim copy of the existing agent)
+
+**Interfaces:**
+- Produces: a subagent named `deslop` (frontmatter `name: deslop`, `tools: Read, Edit, Write, Grep, Glob`) that the orchestrator dispatches for the Edit phase. Owns the slop catalog referenced by reviser, reviewer, and the voice base.
+
+- [ ] **Step 1: Copy the source agent verbatim**
+
+Run:
+````bash
+mkdir -p stilus/agents
+cp /Users/dpuglielli/github/flexion/nucor-bar-mill-schedule/.claude/agents/deslop.md stilus/agents/deslop.md
+````
+
+If that source path no longer exists, the full content was read into the design conversation and is reproduced in the spec history; recreate `stilus/agents/deslop.md` from that content. The file must begin with frontmatter:
+````
+---
+name: deslop
+description: Use to remove AI slop from prose or to draft prose without it; ...
+tools: Read, Edit, Write, Grep, Glob
+---
+````
+
+- [ ] **Step 2: Verify the file is present, non-empty, and has valid frontmatter**
+
+Run:
+````bash
+node -e "const fs=require('fs'); const c=fs.readFileSync('stilus/agents/deslop.md','utf8'); const m=c.match(/^---\n([\s\S]*?)\n---/); if(!m) throw new Error('no frontmatter'); if(!/name:\s*deslop/.test(m[1])) throw new Error('name != deslop'); if(!/tools:/.test(m[1])) throw new Error('no tools'); if(c.length < 2000) throw new Error('suspiciously short ('+c.length+' chars)'); console.log('OK: deslop agent present, '+c.length+' chars, frontmatter valid');"
+````
+Expected: `OK: deslop agent present, <N> chars, frontmatter valid` (N is several thousand).
+
+- [ ] **Step 3: Commit**
+
+````bash
+git add stilus/agents/deslop.md
+git commit -m "$(cat <<'EOF'
+chore - add deslop agent as the stilus edit phase
+
+- subtractive editor, shipped verbatim
+- single source of truth for the slop catalog
+EOF
+)"
+````
+
+---
+
+### Task 3: Voice base and companion doc
+
+**Files:**
+- Create: `stilus/rules/voice.md`
+- Create: `stilus/context/authoring-a-voice.md`
+
+**Interfaces:**
+- Produces: `stilus/voice.md` as the `extends:` target for project profiles, defining the profile schema (persona, registers, vocabulary, mode guidance, additive craft) with neutral defaults. Consumed by the `write` skill (Task 6), reviser (Task 4), and reviewer (Task 5).
+
+- [ ] **Step 1: Create `stilus/rules/voice.md`**
+
+````markdown
+---
+name: voice-base
+domain: voice
+description: Generic voice base for the stilus writing pipeline. Projects extend this with their own register; the Write phase resolves and reads it.
+---
+
+# Voice (generic base)
+
+This file defines the shape of a voice profile and supplies neutral defaults. It carries no personality. The Write phase of stilus reads the resolved voice — project profile over user profile over this base — and drafts in it.
+
+## How a project supplies its voice
+
+Create `.claude/rules/voice.md` in the project (or `~/.claude/rules/voice.md` for a personal default that follows you across repos) with this frontmatter:
+
+```yaml
+---
+extends: stilus/voice.md
+domain: voice
+---
+```
+
+Fill in the sections below. A section you omit falls back to the default here. A section you supply overrides it. Precedence: project profile over user profile over this base.
+
+## What this base does not define
+
+The subtractive catalog (slop patterns, banned constructions, density budgets) and the craft that both drafting and editing share (lead with the point, sentence rhythm, accuracy over precision) live in the deslop agent. This base references them; it never restates them. A voice profile should not restate them either.
+
+## Profile sections
+
+### Persona
+
+Who is writing, in one or two sentences: role, relationship to the audience, the stance the prose takes. Default: a neutral technical author with no personality, who states what a thing does and what it costs.
+
+### Registers
+
+The named registers the author moves between, each with its markers. A project may define one or several. Default: a single neutral analytical register — plain, ordered, unsentimental.
+
+### Preferred and elevated vocabulary
+
+The words this author reaches for, and the rule for when. Default: plain words; no elevated diction.
+
+### Mode guidance
+
+Per-medium conventions. Fill in only the modes that matter.
+
+- Email — opener, body order, length, sign-off. Default: name the recipient, lead with the ask or the answer, keep it short.
+- Slack — Default: one or two sentences, no greeting in active threads.
+- Document or article — Default: topic sentences carry the argument; headers only when the length needs navigation.
+- White paper or report — Default: short paragraphs, argument-driven, specific numbers.
+
+### Additive craft
+
+Positive moves this author makes that deslop does not own:
+
+- Register-driven generation — produce text in the resolved register, not a generic one.
+- Specificity — use the specific number, date, or name when it is available and true.
+- Equip the reader to act — give the reader everything needed to decide without a follow-up round.
+- Analogy as translation — when explaining across domains, map the structure, do not simplify.
+````
+
+- [ ] **Step 2: Create `stilus/context/authoring-a-voice.md`**
+
+````markdown
+# Authoring a voice profile
+
+A voice profile teaches stilus to draft in your register instead of a generic one. It lives in `.claude/rules/voice.md` (per project) or `~/.claude/rules/voice.md` (personal default), and extends the plugin base at `stilus/voice.md`.
+
+## What a profile is for
+
+The profile is the additive layer. It says how this author sounds and what they reach for. It does not list banned words or slop patterns — those live in the deslop agent, and the edit phase applies them after drafting. Keep the profile to voice, not to bans.
+
+## Skeleton
+
+Copy this and fill it in. Delete any section you have no opinion on; the base default applies.
+
+```markdown
+---
+extends: stilus/voice.md
+domain: voice
+companion: .claude/context/voice-notes.md
+---
+
+# Voice
+
+## Persona
+One or two sentences: who writes, to whom, with what stance.
+
+## Registers
+### <register name>
+When it is used, and three to five concrete markers (sentence shapes, moves, tics this author owns).
+
+## Preferred and elevated vocabulary
+Words this author reaches for, and the test for when a word earns its place.
+
+## Mode guidance
+### Email
+Opener, body order, length, sign-off.
+### <other modes that matter>
+
+## Additive craft
+Moves specific to this author beyond the base defaults.
+```
+
+## How it resolves
+
+When you run the write skill, stilus reads the project profile, then the user profile, then the base, and merges them section by section with the higher tier winning. It announces which profile it used. The `companion:` field, if present, points at a longer notes file in `.claude/context/` that stilus also reads.
+
+## Keep it honest
+
+Profiles describe a real voice. If you do not have a settled register for a mode, leave it out rather than invent one. The base default is neutral and safe.
+````
+
+- [ ] **Step 3: Verify both files exist and the base has valid frontmatter**
+
+Run:
+````bash
+node -e "const fs=require('fs'); const v=fs.readFileSync('stilus/rules/voice.md','utf8'); const m=v.match(/^---\n([\s\S]*?)\n---/); if(!m) throw new Error('voice.md: no frontmatter'); if(!/domain:\s*voice/.test(m[1])) throw new Error('voice.md: domain != voice'); if(!/deslop/.test(v)) throw new Error('voice.md does not reference deslop'); fs.readFileSync('stilus/context/authoring-a-voice.md','utf8'); console.log('OK: voice base + companion present, base references deslop');"
+````
+Expected: `OK: voice base + companion present, base references deslop`.
+
+- [ ] **Step 4: Commit**
+
+````bash
+git add stilus/rules/voice.md stilus/context/authoring-a-voice.md
+git commit -m "$(cat <<'EOF'
+chore - add stilus voice base and authoring guide
+
+- generic voice schema with neutral defaults
+- defers slop catalog and shared craft to deslop by reference
+EOF
+)"
+````
+
+---
+
+### Task 4: reviser agent (Revise phase)
+
+**Files:**
+- Create: `stilus/agents/reviser.md`
+
+**Interfaces:**
+- Consumes: a deslopped draft, deslop's report (cuts per category, before/after density rates), and the resolved voice profile.
+- Produces: a subagent named `reviser` (`tools: Read, Edit, Write, Grep, Glob`) that returns revised text plus notes on restorations, reordering, and additions.
+
+- [ ] **Step 1: Create `stilus/agents/reviser.md`**
+
+````markdown
+---
+name: reviser
+description: Revise phase of the stilus pipeline. Adjudicates deslop's cuts and fixes structure. Give it a deslopped draft (with deslop's report) and the resolved voice profile; it restores load-bearing material deslop removed, fixes the thesis and ordering so the piece leads with the point, and addresses completeness. Changes what is said where the piece needs it; makes minimal additions and re-cleans them.
+tools: Read, Edit, Write, Grep, Glob
+---
+
+You revise. You run after the deslop agent has stripped a draft to its skeleton. Your job is to adjudicate that strip and fix structure, not to re-edit line by line.
+
+## What you receive
+
+- The deslopped draft.
+- deslop's report: cuts per category, and before/after density rates.
+- The resolved voice profile (project over user over base).
+
+## What you do
+
+1. Adjudicate the cuts. Read deslop's report. deslop is cut-biased and sometimes removes a load-bearing fact, qualifier, or transition the piece needs. Restore only what the piece genuinely needs. Leave the rest cut.
+2. Fix structure. Make the piece lead with the point at the document and the paragraph level. Reorder so the most important fact comes first. Strengthen a weak or non-refutable thesis.
+3. Address completeness. Name anything the reader needs that is missing, and add it.
+
+## Contracts
+
+- You may change what is said and reorder. This is the phase that does.
+- Keep additions minimal. Re-clean anything you add against the deslop catalog before returning. Do not reintroduce slop.
+- The subtractive catalog and the shared craft (lead with the point, sentence rhythm, accuracy over precision) live in the deslop agent and the voice base. Reference them; do not restate them.
+- Stay in the resolved voice. Do not flatten the author's register or vocabulary.
+
+## What you return
+
+The revised text, edited in place if you were given a file path. Then a short note: which cuts you restored and why, what you reordered, and what you added.
+````
+
+- [ ] **Step 2: Verify frontmatter and the may/may-not contract are present**
+
+Run:
+````bash
+node -e "const fs=require('fs'); const c=fs.readFileSync('stilus/agents/reviser.md','utf8'); const m=c.match(/^---\n([\s\S]*?)\n---/); if(!m) throw new Error('no frontmatter'); if(!/name:\s*reviser/.test(m[1])) throw new Error('name != reviser'); if(!/Edit/.test(m[1])) throw new Error('reviser needs Edit tool'); if(!/do not restate/.test(c)) throw new Error('missing cross-reference discipline'); console.log('OK: reviser agent valid');"
+````
+Expected: `OK: reviser agent valid`.
+
+- [ ] **Step 3: Commit**
+
+````bash
+git add stilus/agents/reviser.md
+git commit -m "$(cat <<'EOF'
+chore - add reviser agent as the stilus revise phase
+
+- adjudicates deslop cuts, fixes structure and completeness
+- references the deslop catalog rather than restating it
+EOF
+)"
+````
+
+---
+
+### Task 5: reviewer agent (Review phase)
+
+**Files:**
+- Create: `stilus/agents/reviewer.md`
+
+**Interfaces:**
+- Consumes: the piece (after write → edit → revise), its stated purpose and audience, and the resolved voice profile.
+- Produces: a read-only subagent named `reviewer` (`tools: Read, Grep, Glob` — no Edit/Write) that returns a verdict (`PASS`/`FAIL`) plus a findings list. The orchestrator routes a `FAIL`'s findings back to `reviser`.
+
+- [ ] **Step 1: Create `stilus/agents/reviewer.md`**
+
+````markdown
+---
+name: reviewer
+description: Review phase of the stilus pipeline. An independent, read-only judge of finished prose. Give it the piece, its purpose and audience, and the resolved voice profile; it judges fit, flags surviving AI tells and density-budget violations, verifies no invented specifics, and confirms register match. It does not edit. Returns a verdict and findings; a fail sends the piece back to revise.
+tools: Read, Grep, Glob
+---
+
+You review. You judge a finished piece against what it is for. You do not edit. You produce a verdict and findings, and the orchestrator decides whether to send the piece back.
+
+## What you receive
+
+- The piece, after write, edit, and revise.
+- Its stated purpose and audience.
+- The resolved voice profile.
+
+## What you check
+
+1. Purpose and audience fit. Does the piece do its job for this reader? Does it lead with the point, so a reader who stops early still has it?
+2. Surviving tells. Run the deslop catalog's density budgets over the piece: contrast pivots, totalizing quantifiers, disguised lists, echoes. Report the per-1,000-word rates and flag any over budget. Flag any banned construction that survived.
+3. Accuracy over precision. Flag any specific (number, date, name, citation) that reads as invented or unverified. A vague-but-true claim beats a precise-but-false one.
+4. Register match. Does the piece sound like the resolved voice profile, in the right register for the mode?
+
+## Contracts
+
+- Read-only. You have no Edit or Write tool. You never change the piece.
+- The subtractive catalog and the density budgets live in the deslop agent; reference them, do not restate them. The register lives in the voice profile.
+
+## What you return
+
+A verdict, PASS or FAIL, and a findings list. For each finding: the span, the category, and the specific fix. On FAIL, the orchestrator routes your findings back to the revise phase.
+````
+
+- [ ] **Step 2: Verify the reviewer is read-only and has the rubric**
+
+Run:
+````bash
+node -e "const fs=require('fs'); const c=fs.readFileSync('stilus/agents/reviewer.md','utf8'); const m=c.match(/^---\n([\s\S]*?)\n---/); if(!m) throw new Error('no frontmatter'); if(!/name:\s*reviewer/.test(m[1])) throw new Error('name != reviewer'); if(/Edit|Write/.test(m[1].match(/tools:.*/)[0])) throw new Error('reviewer must NOT have Edit/Write'); if(!/PASS|FAIL/.test(c)) throw new Error('no verdict format'); console.log('OK: reviewer agent valid and read-only');"
+````
+Expected: `OK: reviewer agent valid and read-only`.
+
+- [ ] **Step 3: Commit**
+
+````bash
+git add stilus/agents/reviewer.md
+git commit -m "$(cat <<'EOF'
+chore - add reviewer agent as the stilus review phase
+
+- read-only judge: fit, surviving tells, accuracy, register
+- returns PASS/FAIL plus findings; fail loops back to revise
+EOF
+)"
+````
+
+---
+
+### Task 6: Orchestrator skill (Write phase + pipeline)
+
+**Files:**
+- Create: `stilus/skills/write/SKILL.md`
+
+**Interfaces:**
+- Consumes: the voice base (`stilus/rules/voice.md`), and the `deslop`, `reviser`, and `reviewer` subagents from Tasks 2, 4, 5.
+- Produces: the skill `stilus:write`, the plugin's on-demand entry point.
+
+- [ ] **Step 1: Create `stilus/skills/write/SKILL.md`**
+
+````markdown
+---
+name: stilus:write
+description: Use when drafting, editing, polishing, or rewriting prose that will be sent or published — emails, Slack messages, documents, articles, white papers. Drafts in the project's voice, then runs an adaptive write/edit/revise/review pipeline. Do not use when the user wants information for themselves (research, debugging, brainstorming) and the output is not meant to be sent.
+---
+
+# Stilus — write
+
+You run an adaptive writing pipeline. You draft in the project's voice, then escalate through edit, revise, and review as the piece warrants.
+
+## Step 0 — Load the voice
+
+Before drafting, resolve the voice profile:
+
+1. Scan for a project voice:
+   ```bash
+   find .claude/rules -name '*.md' 2>/dev/null
+   ```
+2. Read any voice profile — match by frontmatter `domain: voice` or `extends: stilus/voice.md`, or by filename `voice.md`.
+3. Read the user default at `~/.claude/rules/voice.md` if present.
+4. Read the plugin base at this plugin's `rules/voice.md`.
+5. Resolve precedence: project over user over base. A section present in a higher tier overrides the same section below it.
+6. State the source: "Using voice from `<path>`" or "No project voice, using base."
+7. Check for a companion: if a voice profile's frontmatter has a `companion:` field, read that file too.
+
+## Step 1 — Classify and choose depth
+
+Infer the mode (Slack, email, document, article, white paper) and the stakes.
+
+- Default depth: write → edit → revise.
+- Short or casual (Slack, a quick reply): write → edit.
+- Published, external, or high-stakes (white paper, public post, anything sent to someone who matters): write → edit → revise → review.
+
+Explicit user phrases override the default:
+
+- "just draft" or "draft only" → write only.
+- "edit only" or "deslop this" → edit only; the user supplied the text, so skip write.
+- "full review" → force write → edit → revise → review.
+- "critique only" → run deslop's critique phase, or the reviewer, without applying edits.
+
+State the chosen depth in one line before proceeding.
+
+## Step 2 — Write
+
+Draft the piece in the resolved voice, here in this conversation, using the additive craft from the voice base. Do not restate the deslop catalog; the edit phase owns it.
+
+## Step 3 — Edit (subtractive)
+
+Launch the deslop subagent on the draft. It returns the edited text plus its report (cuts per category, before and after density rates). Keep the report; revise and review consume it.
+
+## Step 4 — Revise (depth at least 3)
+
+Launch the reviser subagent with the deslopped draft, deslop's report, and the resolved voice profile. It adjudicates the cuts, fixes structure, and addresses completeness, then returns revised text plus notes.
+
+## Step 5 — Review (depth 4)
+
+Launch the reviewer subagent with the piece, its purpose and audience, and the voice profile. It returns a verdict and findings.
+
+- On PASS, deliver.
+- On FAIL, route the findings back to the reviser once, then deliver. Do not loop more than once. Match effort to what the piece is worth.
+
+## Subagents
+
+Dispatch each phase to the matching agent shipped by this plugin: `deslop` (edit), `reviser` (revise), `reviewer` (review). If the platform namespaces plugin agents, use the namespaced name; the agent names are unique within this plugin.
+
+## Output
+
+Edit the file in place when given a path; return the text when given raw input. End with a one-line provenance note: which phases ran and what changed.
+````
+
+- [ ] **Step 2: Verify the skill frontmatter and that it references all three agents and the voice scan**
+
+Run:
+````bash
+node -e "const fs=require('fs'); const c=fs.readFileSync('stilus/skills/write/SKILL.md','utf8'); const m=c.match(/^---\n([\s\S]*?)\n---/); if(!m) throw new Error('no frontmatter'); if(!/name:\s*stilus:write/.test(m[1])) throw new Error('name != stilus:write'); for(const a of ['deslop','reviser','reviewer']) if(!c.includes(a)) throw new Error('skill does not reference '+a); if(!/extends: stilus\/voice.md|domain: voice/.test(c)) throw new Error('no voice scan'); if(!/~\/.claude\/rules\/voice.md/.test(c)) throw new Error('no user-tier voice scan'); console.log('OK: orchestrator skill references all phases and the voice scan order');"
+````
+Expected: `OK: orchestrator skill references all phases and the voice scan order`.
+
+- [ ] **Step 3: Commit**
+
+````bash
+git add stilus/skills/write/SKILL.md
+git commit -m "$(cat <<'EOF'
+chore - add stilus write skill as the adaptive orchestrator
+
+- resolves voice (project > user > base), classifies depth
+- dispatches deslop/reviser/reviewer; review loops to revise once
+EOF
+)"
+````
+
+---
+
+### Task 7: Docs updates and final validation
+
+**Files:**
+- Modify: `CLAUDE.md` (version-bump note; repo-structure tree; Context Ownership table)
+
+**Interfaces:**
+- Produces: documentation consistent with the new plugin, and a whole-plugin validation gate.
+
+- [ ] **Step 1: Add `stilus/` to the version-bump IMPORTANT note in `CLAUDE.md`**
+
+Change:
+````markdown
+**IMPORTANT: Before completing work on any branch that modifies plugin files (mantra/, memento/, onus/, agent-artifex/), run `node scripts/bump-version.js <plugin> <patch|minor|major>` for each affected plugin. Do not merge without bumping.**
+````
+to:
+````markdown
+**IMPORTANT: Before completing work on any branch that modifies plugin files (mantra/, memento/, onus/, agent-artifex/, stilus/), run `node scripts/bump-version.js <plugin> <patch|minor|major>` for each affected plugin. Do not merge without bumping.**
+````
+
+- [ ] **Step 2: Update the Repository Structure tree in `CLAUDE.md`**
+
+Change:
+````markdown
+claude-domestique/
+├── .claude-plugin/          # Marketplace root plugin config
+├── mantra/                  # Context refresh plugin
+├── memento/                 # Session persistence plugin
+└── onus/                    # Work item automation plugin
+````
+to:
+````markdown
+claude-domestique/
+├── .claude-plugin/          # Marketplace root plugin config
+├── mantra/                  # Context refresh plugin
+├── memento/                 # Session persistence plugin
+├── onus/                    # Work item automation plugin
+├── agent-artifex/           # AI design & testing guidance plugin
+└── stilus/                  # Writing pipeline plugin
+````
+
+- [ ] **Step 3: Add the `stilus` row to the Context Ownership table in `CLAUDE.md`**
+
+Change:
+````markdown
+| **onus** | Git operations, work items | `rules/git.md`, `rules/work-items.md` |
+````
+to:
+````markdown
+| **onus** | Git operations, work items | `rules/git.md`, `rules/work-items.md` |
+| **stilus** | Prose drafting and editing | `agents/deslop.md` (subtractive catalog), `rules/voice.md` (voice schema), `agents/reviser.md`, `agents/reviewer.md` |
+````
+
+- [ ] **Step 4: Validate the whole plugin's structure and JSON**
+
+Run:
+````bash
+node -e "
+const fs=require('fs'), path=require('path');
+// JSON validity
+JSON.parse(fs.readFileSync('stilus/.claude-plugin/plugin.json','utf8'));
+JSON.parse(fs.readFileSync('stilus/package.json','utf8'));
+const m=JSON.parse(fs.readFileSync('.claude-plugin/marketplace.json','utf8'));
+if(!m.plugins.find(p=>p.name==='stilus')) throw new Error('stilus missing from marketplace');
+// every agent + skill has frontmatter with a name
+const mdFiles=['stilus/agents/deslop.md','stilus/agents/reviser.md','stilus/agents/reviewer.md','stilus/skills/write/SKILL.md','stilus/rules/voice.md'];
+for(const f of mdFiles){ const c=fs.readFileSync(f,'utf8'); const fm=c.match(/^---\n([\s\S]*?)\n---/); if(!fm) throw new Error(f+': no frontmatter'); if(!/name:/.test(fm[1])) throw new Error(f+': no name'); }
+// plugin.json must NOT carry a version (marketplace-level only)
+const pj=JSON.parse(fs.readFileSync('stilus/.claude-plugin/plugin.json','utf8'));
+if('version' in pj) throw new Error('plugin.json must not carry a version');
+// CLAUDE.md docs updated
+const cm=fs.readFileSync('CLAUDE.md','utf8');
+if(!/agent-artifex\/, stilus\//.test(cm)) throw new Error('version-bump note not updated');
+if(!/\*\*stilus\*\* \| Prose drafting/.test(cm)) throw new Error('Context Ownership row missing');
+console.log('OK: stilus plugin structure, JSON, and docs all valid');
+"
+````
+Expected: `OK: stilus plugin structure, JSON, and docs all valid`.
+
+- [ ] **Step 5: Manual smoke test (requires a live Claude Code session; not automated)**
+
+This cannot be unit-tested — the deliverables are prompts. Verify behavior by hand:
+
+1. Add the local marketplace if not already added, and install/enable `stilus`.
+2. In a repo with no `.claude/rules/voice.md`, ask the skill to draft a short message. Confirm it announces "No project voice, using base" and runs write → edit (deslop).
+3. Create a `.claude/rules/voice.md` with `extends: stilus/voice.md` and a distinctive register. Re-run. Confirm it announces "Using voice from `.claude/rules/voice.md`" and the draft reflects that register.
+4. Ask for a "white paper" or say "full review." Confirm it escalates to write → edit → revise → review and that the reviewer returns a verdict.
+5. Confirm the `deslop`, `reviser`, and `reviewer` agents are discoverable as subagents and that the orchestrator dispatches them.
+
+Record the outcome in the PR description. If subagent dispatch needs a namespaced agent name on this platform, note the exact form.
+
+- [ ] **Step 6: Commit**
+
+````bash
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+chore - document stilus plugin in CLAUDE.md
+
+- add stilus to version-bump note, repo structure, ownership table
+EOF
+)"
+````
+
+---
+
+## Known limitations / optional follow-ups
+
+- `bump-version.js` still reads the current version from `<plugin>/package.json`. stilus now has one, so it bumps correctly. agent-artifex still does not — a separate fix (give agent-artifex a `package.json`, or refactor `bump-version.js` to source the version from `marketplace.json`) is out of scope here.
+- Optional `/stilus:deslop <file>` and `/stilus:review` commands for explicit single-phase invocation are deferred.
+- Migrating the personal `writing` skill into a `~/.claude/rules/voice.md` profile is a separate task that also validates the abstraction.
+
+## Self-Review
+
+**Spec coverage.** Every spec section maps to a task: the four phase contracts → deslop (T2), reviser (T4), reviewer (T5), write/orchestrator (T6); component layout → all tasks; voice schema + scan order → T3 (base) and T6 (resolution); orchestrator behavior → T6; single source of truth → enforced by T2's catalog ownership and the cross-reference discipline in T3/T4/T5/T6; marketplace/versioning/tests → T1 and T7; the three spec open items → resolved (bump-version in T1; reviser/reviewer prompts in T4/T5; depth heuristics in T6 Step 1).
+
+**Placeholder scan.** No "TBD"/"TODO"/"handle edge cases". The deslop copy names an exact source path plus a fallback. The only non-automated step (T7 Step 5) is explicitly labeled manual because prompt behavior has no unit-test harness.
+
+**Type/name consistency.** Agent names are consistent across tasks and the orchestrator: `deslop`, `reviser`, `reviewer`. The skill name `stilus:write` matches its verification. The voice frontmatter contract (`extends: stilus/voice.md`, `domain: voice`) is identical in the base (T3), companion (T3), and the orchestrator's scan (T6). Version `0.1.0` is consistent across `package.json`, `marketplace.json`, and the validation in T7.

--- a/docs/superpowers/plans/2026-06-24-stilus-reviewer-redesign.md
+++ b/docs/superpowers/plans/2026-06-24-stilus-reviewer-redesign.md
@@ -1,0 +1,582 @@
+# Stilus Reviewer Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the unbuilt single stilus `reviewer` agent with an orchestrated review phase — three parallel read-only specialists plus orchestrator synthesis — exposed standalone via `/stilus:review` and reviewing along four dimensions (correctness, graded slop, human perception, AI-perception round-trip).
+
+**Architecture:** A skill/agent/command plugin addition, no JS. The review phase fans out to three read-only subagents (`review-correctness`, `review-voice`, `review-summary`), then synthesizes in the orchestrator's own context — comparing the blind summary to the intended point, merging findings, scoring each dimension, and writing a verdict-bearing report. All shared synthesis logic lives in one context doc so the command and (later) the write skill do not duplicate it.
+
+**Tech Stack:** Markdown prompt files (agents, command, context doc), edits to `README.md` and `CLAUDE.md`. No test framework — like agent-artifex and the rest of stilus, this is pure prompts/config; verification is frontmatter/structure checks via inline `node` plus a manual smoke test.
+
+## Global Constraints
+
+- **No JS tests.** This plugin ships no Jest suite. Verification is inline `node -e` checks, not committed tests.
+- **All three specialists are read-only.** No `Edit`, no `Write`, ever. `review-summary` gets `Read` only; `review-voice` gets `Read, Grep, Glob`; `review-correctness` gets `Read, Grep, Glob, WebSearch, WebFetch`.
+- **The blind summarizer is blind.** `review-summary` receives ONLY the prose — never the purpose, audience, or intended point. Its blindness is the mechanism for the AI-perception test.
+- **deslop is the single source of truth for the slop catalog.** `stilus/agents/deslop.md` is NOT modified by this plan. The specialists reference it (catalog, density budgets, accuracy-over-precision); they never restate it.
+- **Every finding is grounded in a direct quotation** from the reviewed document. A finding without a quotation does not ship.
+- **Synthesis runs in the orchestrator (main context),** never in a subagent. The shared synthesis logic lives once in `stilus/context/reviewing.md`; the command and the write skill reference it.
+- **On-demand only.** No hooks, no global injection.
+- **Version: stilus stays at `0.1.0`.** stilus is introduced by this branch and has never shipped; `0.1.0` is its introductory version, so there is nothing to bump from. Do not run `bump-version.js` for this plan.
+- **Commit format:** `chore - <lowercase description>`, HEREDOC, no attribution, no emojis. Work continues on branch `chore/add-stilus-plugin`.
+- **Out of scope:** building the `reviser` agent and the `write` skill (separate work from the original `2026-06-18-stilus-writing-plugin.md` plan); wiring the review phase into the write skill's review step (a thin reference to `context/reviewing.md`, done when the write skill is built); changing `deslop.md`, `reviser.md`, or `rules/voice.md`.
+
+## File Structure
+
+Files created or modified, each with one responsibility:
+
+- `stilus/agents/review-summary.md` — **Create.** Blind summarizer. Reports what a cold reader extracts. Feeds the AI-perception dimension.
+- `stilus/agents/review-voice.md` — **Create.** Slop detection graded 1–5 plus the human-perception read. Owns the severity scale and the perception rubric.
+- `stilus/agents/review-correctness.md` — **Create.** Internal soundness, verify-when-possible, and the claims-to-verify-by-hand list. Owns the correctness rubric.
+- `stilus/context/reviewing.md` — **Create.** The orchestrator's playbook: intent capture, fan-out, AI-perception comparison, dedup, dimension scoring, verdict thresholds, report format. SSOT for synthesis.
+- `stilus/commands/review.md` — **Create.** The `/stilus:review` standalone entry point. Thin; defers to `context/reviewing.md`.
+- `stilus/README.md` — **Modify.** Update the Review bullet and SSOT line; mention `/stilus:review` and the four dimensions.
+- `CLAUDE.md` — **Modify.** Add the stilus row to the Context Ownership table.
+
+Task order: 1 (review-summary) → 2 (review-voice) → 3 (review-correctness) → 4 (reviewing.md, which references all three agents) → 5 (command, which references reviewing.md) → 6 (docs + whole-plugin validation + manual smoke test).
+
+---
+
+### Task 1: review-summary agent (blind summarizer)
+
+**Files:**
+- Create: `stilus/agents/review-summary.md`
+
+**Interfaces:**
+- Produces: a read-only subagent named `review-summary` (`tools: Read`) that receives only prose and returns a cold reader's takeaway (the point in one sentence, key claims, the two-sentence "what was this about", and where it stalled). The orchestrator (`context/reviewing.md`, Task 4) dispatches it and feeds its output into the AI-perception comparison.
+
+- [ ] **Step 1: Create `stilus/agents/review-summary.md`**
+
+````markdown
+---
+name: review-summary
+description: Blind summarizer for the stilus review phase. Give it ONLY a piece of prose (a file path or raw text) and nothing else — no intended point, no purpose, no rubric. It reports what a cold reader takes away: the point in one sentence, the key claims, a two-sentence "what was this about", and where it stalled. Used to test AI perception — whether the writing's point survives an independent machine read.
+tools: Read
+---
+
+You are a cold reader. You receive a piece of prose and nothing else: no statement of what it is for, no intended takeaway, no checklist. Report only what the text itself conveys to you on a first read.
+
+## What you receive
+
+A file path to read, or raw text. Nothing about its purpose, audience, or intended point. If any context about intent reached you, ignore it; your value is that you did not know.
+
+## What you do
+
+Read the piece once, as a reader who will act on it or pass it along. Then report:
+
+1. **The point, in one sentence.** What is this piece actually saying? If you cannot find a single point, say so — that is itself the finding.
+2. **Key claims.** The three to six load-bearing claims you would carry away.
+3. **What you would tell someone.** If a colleague asked "what was that about?", your two-sentence answer.
+4. **Where you stalled.** Any passage you had to reread, skip, or could not parse. Name the span.
+
+## Contracts
+
+- Read-only. You never edit.
+- Do not judge quality, grade slop, or check facts. You only report what got through to you.
+- Do not flatter the text or fill gaps. If the point did not land, report that it did not. A blank or muddled takeaway is the most useful result you can return.
+- Report what you actually extracted, not what you infer the author probably meant.
+
+## What you return
+
+The four items above, plainly, with no preamble.
+````
+
+- [ ] **Step 2: Verify the file is present, blind, and read-only**
+
+Run:
+````bash
+node -e "const fs=require('fs'); const c=fs.readFileSync('stilus/agents/review-summary.md','utf8'); const m=c.match(/^---\n([\s\S]*?)\n---/); if(!m) throw new Error('no frontmatter'); if(!/name:\s*review-summary/.test(m[1])) throw new Error('name != review-summary'); const t=m[1].match(/tools:.*/)[0]; if(/Edit|Write|Grep|Glob/.test(t)) throw new Error('summarizer must be Read-only: '+t); if(!/cold reader/.test(c)) throw new Error('missing cold-reader framing'); if(!/never edit/i.test(c)) throw new Error('missing read-only contract'); console.log('OK: review-summary present, blind, Read-only');"
+````
+Expected: `OK: review-summary present, blind, Read-only`.
+
+- [ ] **Step 3: Commit**
+
+````bash
+git add stilus/agents/review-summary.md
+git commit -m "$(cat <<'EOF'
+chore - add stilus review-summary blind summarizer agent
+
+- read-only cold reader; sees only the prose, no intent
+- feeds the AI-perception round-trip in synthesis
+EOF
+)"
+````
+
+---
+
+### Task 2: review-voice agent (graded slop + human perception)
+
+**Files:**
+- Create: `stilus/agents/review-voice.md`
+
+**Interfaces:**
+- Consumes: the piece and the resolved voice profile.
+- Produces: a read-only subagent named `review-voice` (`tools: Read, Grep, Glob`) returning slop findings each graded 1–5 with a quoted span, the deslop category, the reason, and a fix; the per-1,000-word density rates; and the human-perception read (a keep-reading verdict plus bail-point spans). Owns the 1–5 severity scale and the human-perception rubric.
+
+- [ ] **Step 1: Create `stilus/agents/review-voice.md`**
+
+````markdown
+---
+name: review-voice
+description: Voice critic for the stilus review phase. Give it a piece of prose plus the resolved voice profile. It detects AI slop independently against the deslop catalog, grades each finding 1-5 by severity, reports the density-budget rates, and judges human perception — whether a reader will bail on a wall of text, undefined jargon, filler, or a buried point. Read-only; returns graded, quotation-grounded findings, not edits.
+tools: Read, Grep, Glob
+---
+
+You judge how prose reads — to a person. You detect AI slop and grade how badly each instance hurts, and you judge whether a human reader keeps going or bails. You do not edit, and you do not restate the slop catalog: the patterns, density budgets, and the accuracy-over-precision rule live in the deslop agent (`stilus/agents/deslop.md`), the single source of truth. You apply that catalog and add the severity scale and the human-perception read below.
+
+## What you receive
+
+- The piece: a file path or raw text.
+- The resolved voice profile (project over user over base), so you grade against the intended register, not a generic one.
+
+## What you do
+
+### 1. Detect slop, independently
+
+Run the deslop catalog over the piece yourself; do not assume a prior edit pass caught everything. Measure the density budgets deslop defines (contrast pivots, totalizing quantifiers, disguised lists, echoes) and report the per-1,000-word rates. Flag each instance with the catalog category it matches.
+
+### 2. Grade each finding 1–5
+
+Score every slop finding by how much it costs the reader. Anchor to these levels:
+
+- **1 — Defensible.** A light tell, arguable in context. One stray style word ("robust"), a single mild hedge. Note it; lowest priority.
+- **2 — Minor.** Cut on sight, harmless to meaning. A filler word ("really," "just"), an "in order to," a lone padding phrase.
+- **3 — Noticeable.** A clear machine habit; the reader senses an AI wrote this. A relief structure ("the test suite is the safety net: it catches problems before they ship"), a participial summary tail ("...demonstrating its flexibility"), a tricolon riding for rhythm.
+- **4 — Degrading.** Actively erodes trust or clarity. Stacked tells in one passage, booster register (every result "exciting," every approach "powerful"), a posture declarative standing in for a fact ("We treat both sections as binding").
+- **5 — Reading-stopping.** Empty performance, a wall of words, or meaninglessness a reader bounces off. An overloaded sentence warehousing five facts, a paragraph of pure throat-clearing, a disguised list where every sentence is "thesis: a, b, and c," a point buried under so much scaffolding the reader leaves without it.
+
+When a span fits two levels, grade the higher. Report the distribution (how many of each level).
+
+### 3. Judge human perception
+
+Will a human reader keep going, or bail? Cover:
+
+- **Wall of text** — sentences or paragraphs so long the reader skips them. Name the spans.
+- **Unnecessary jargon** — undefined terms or insider shorthand this audience will not parse.
+- **Meaninglessness** — filler that signals value without delivering it; the reader gets nothing.
+- **Buried or absent point** — a reader who stops early leaves without the takeaway.
+
+Give a one-line "will they keep reading?" verdict and the specific spans that cause drop-off.
+
+## Contracts
+
+- Read-only. You never edit.
+- The slop catalog, density budgets, and accuracy-over-precision rule live in deslop; reference them, do not restate them. The register lives in the voice profile.
+- Ground every finding in a direct quotation from the piece. No quotation, no finding.
+
+## What you return
+
+1. The slop findings, each with: the quoted span, the deslop category, the 1–5 severity, why it costs the reader, and a concrete fix.
+2. The slop severity distribution and the density-budget rates per 1,000 words.
+3. The human-perception read: the keep-reading verdict plus the bail-point spans.
+````
+
+- [ ] **Step 2: Verify frontmatter, read-only tools, the 1–5 scale, and cross-reference discipline**
+
+Run:
+````bash
+node -e "const fs=require('fs'); const c=fs.readFileSync('stilus/agents/review-voice.md','utf8'); const m=c.match(/^---\n([\s\S]*?)\n---/); if(!m) throw new Error('no frontmatter'); if(!/name:\s*review-voice/.test(m[1])) throw new Error('name != review-voice'); const t=m[1].match(/tools:.*/)[0]; if(/Edit|Write/.test(t)) throw new Error('review-voice must be read-only: '+t); for(const lvl of ['1 — Defensible','2 — Minor','3 — Noticeable','4 — Degrading','5 — Reading-stopping']) if(!c.includes(lvl)) throw new Error('missing severity level: '+lvl); if(!/human perception/i.test(c)) throw new Error('missing human-perception read'); if(!/do not restate/.test(c)) throw new Error('missing cross-reference discipline'); if(!/No quotation, no finding/.test(c)) throw new Error('missing quotation-grounding rule'); console.log('OK: review-voice valid (5-level scale, perception, read-only, cross-ref)');"
+````
+Expected: `OK: review-voice valid (5-level scale, perception, read-only, cross-ref)`.
+
+- [ ] **Step 3: Commit**
+
+````bash
+git add stilus/agents/review-voice.md
+git commit -m "$(cat <<'EOF'
+chore - add stilus review-voice agent (graded slop + perception)
+
+- detects slop against the deslop catalog, grades each finding 1-5
+- adds the human-perception read; references deslop, does not restate it
+EOF
+)"
+````
+
+---
+
+### Task 3: review-correctness agent
+
+**Files:**
+- Create: `stilus/agents/review-correctness.md`
+
+**Interfaces:**
+- Consumes: the piece and any codebase/domain context.
+- Produces: a read-only subagent named `review-correctness` (`tools: Read, Grep, Glob, WebSearch, WebFetch`) returning soundness findings (quoted span, category, reason, fix), verification results with sources, and a separate "claims to verify by hand" list. Owns the correctness rubric.
+
+- [ ] **Step 1: Create `stilus/agents/review-correctness.md`**
+
+````markdown
+---
+name: review-correctness
+description: Correctness critic for the stilus review phase. Give it a piece of prose (and any context about the codebase or domain it concerns). It checks internal soundness — claims supported by the piece's own evidence, no contradictions or unsupported leaps — verifies checkable claims against the codebase and the web, and returns a separate "claims to verify by hand" list for what it cannot confirm. Read-only; returns quotation-grounded findings, not edits.
+tools: Read, Grep, Glob, WebSearch, WebFetch
+---
+
+You judge whether a piece is correct and whether its content holds together. You do not edit.
+
+## What you receive
+
+- The piece: a file path or raw text.
+- Whatever context exists about the codebase, repo, or domain the piece concerns.
+
+## What you do
+
+### 1. Internal soundness
+
+Read the argument as a skeptic. Flag:
+
+- Claims the piece asserts but does not support with its own stated evidence.
+- Contradictions — two passages that cannot both be true.
+- Unsupported leaps — a conclusion that does not follow from what precedes it.
+- Missing content the reader needs to act on the piece's own terms.
+
+### 2. Verify what is checkable
+
+When a claim is verifiable, verify it:
+
+- **About this repo or codebase** — use Read, Grep, and Glob to confirm. Flag claims the code contradicts (a named file that does not exist, a described behavior the code does not have).
+- **Public facts** — use WebSearch and WebFetch to confirm names, dates, figures, and citations where a quick check settles it. Flag what is wrong.
+
+### 3. Flag for human
+
+Build a separate "claims to verify by hand" list: external or factual claims you cannot confirm yourself (private data, unpublished facts, anything a search does not settle). List them so nothing factual passes silently.
+
+### 4. Accuracy over precision
+
+Flag specifics — numbers, dates, names, citations — that read as invented or unverifiable. This rule lives in the deslop agent (`stilus/agents/deslop.md`); reference it, do not restate it. A vague-but-true claim beats a precise-but-false one.
+
+## Contracts
+
+- Read-only. You never edit the piece.
+- Ground every finding in a direct quotation from the piece. No quotation, no finding.
+- Distinguish what you verified and disproved from what you could not check. Never present an unverified claim as confirmed either way.
+
+## What you return
+
+1. Soundness findings, each with: the quoted span, the category (unsupported / contradiction / leap / missing), why, and the fix.
+2. Verification results: the claims you checked, what you found, and the source.
+3. The "claims to verify by hand" list.
+````
+
+- [ ] **Step 2: Verify frontmatter, web tools, no-edit, and the flag-for-human list**
+
+Run:
+````bash
+node -e "const fs=require('fs'); const c=fs.readFileSync('stilus/agents/review-correctness.md','utf8'); const m=c.match(/^---\n([\s\S]*?)\n---/); if(!m) throw new Error('no frontmatter'); if(!/name:\s*review-correctness/.test(m[1])) throw new Error('name != review-correctness'); const t=m[1].match(/tools:.*/)[0]; if(/Edit|Write/.test(t)) throw new Error('review-correctness must not edit: '+t); if(!/WebSearch/.test(t)||!/WebFetch/.test(t)) throw new Error('needs WebSearch and WebFetch for verification'); if(!/claims to verify by hand/.test(c)) throw new Error('missing flag-for-human list'); if(!/do not restate/.test(c)) throw new Error('missing cross-reference discipline'); if(!/No quotation, no finding/.test(c)) throw new Error('missing quotation-grounding rule'); console.log('OK: review-correctness valid (verify + flag-for-human, read-only)');"
+````
+Expected: `OK: review-correctness valid (verify + flag-for-human, read-only)`.
+
+- [ ] **Step 3: Commit**
+
+````bash
+git add stilus/agents/review-correctness.md
+git commit -m "$(cat <<'EOF'
+chore - add stilus review-correctness agent
+
+- internal soundness, verify-when-possible via codebase/web
+- separate claims-to-verify-by-hand list; references deslop accuracy rule
+EOF
+)"
+````
+
+---
+
+### Task 4: reviewing.md (synthesis playbook)
+
+**Files:**
+- Create: `stilus/context/reviewing.md`
+
+**Interfaces:**
+- Consumes: the `review-correctness`, `review-voice`, and `review-summary` subagents (Tasks 1–3).
+- Produces: the single source of truth for the review flow — intent capture, parallel fan-out, the AI-perception comparison, finding dedup, per-dimension scoring, verdict thresholds, and the report format. Consumed by the `/stilus:review` command (Task 5) and, later, the write skill's review step.
+
+- [ ] **Step 1: Create `stilus/context/reviewing.md`**
+
+`````markdown
+# Reviewing — the stilus review phase
+
+This document is the single source of truth for how stilus reviews a finished piece. The `/stilus:review` command and the write skill's review step both run this flow. It owns synthesis: how the review phase gathers intent, fans out to the specialist agents, compares the blind summary to the intended point, dedups and scores findings, assigns a verdict, and writes the report. The per-dimension rubrics live in the specialist agents, not here.
+
+## The flow
+
+### Step 1 — Gather intent
+
+Establish three things before dispatching:
+
+- **Purpose** — what the piece is for.
+- **Audience** — who reads it.
+- **Intended point** — the one thing the reader should take away.
+
+In the pipeline these come from the drafting context. Standalone, ask the user for them in one prompt. If the user supplies none, proceed with intent unknown: the AI-perception step becomes a mirror (Step 3) rather than a pass/fail.
+
+### Step 2 — Fan out (parallel, read-only)
+
+Dispatch all three specialists on the same target in a single batch so they run concurrently. Each is read-only and independent.
+
+- `review-correctness` — pass the piece and any codebase/domain context.
+- `review-voice` — pass the piece and the resolved voice profile.
+- `review-summary` — pass ONLY the piece. Do not pass the purpose, audience, or intended point. Its blindness is the point.
+
+If the platform namespaces plugin agents, use the namespaced name; the names are unique within this plugin.
+
+### Step 3 — AI perception (synthesis)
+
+Compare `review-summary`'s blind takeaway to the intended point:
+
+- **Intent known:** Did the point survive? Where the blind summary diverges from the intended point — wrong emphasis, missing the main claim, a misread — the prose failed to carry the point to a machine reader. Report the gap as a finding.
+- **Intent unknown:** Present the blind takeaway to the user as a mirror: "An AI reading this cold took away: <summary>. Is that your point?" Do not score this case; surface it for confirmation.
+
+### Step 4 — Merge and dedup
+
+Combine the three findings sets. When two specialists flag the same span (for example, review-voice flags it as a disguised list and review-correctness flags the same span as an unsupported leap), merge into one finding that carries both lenses and the higher severity. Order findings by severity, highest first.
+
+### Step 5 — Score and judge
+
+Score each dimension:
+
+- **Correctness** — PASS if no unsupported claims, contradictions, or disproven facts survive; FAIL if any do. Always attach the claims-to-verify-by-hand list regardless of score.
+- **Voice** — PASS if no slop finding is 4 or 5 and all density budgets are within deslop's limits; CONCERN if the worst finding is 3 or a budget is mildly over; FAIL if any finding is 5 or budgets are well over.
+- **Human perception** — PASS if a reader keeps going; CONCERN if there are isolated bail points; FAIL if the piece reads as a wall of words or the point is buried.
+- **AI perception** — PASS if the blind takeaway matches the intended point; FAIL if it diverges; `mirror` if intent is unknown (unscored).
+
+**Overall verdict:** FAIL if any dimension is FAIL; CONCERN if any is CONCERN and none is FAIL; otherwise PASS. A `mirror` AI-perception result does not by itself raise the verdict.
+
+In the pipeline, a FAIL drives one bounded loop-back to the reviser, then deliver regardless of the second result. Standalone, the verdict is the assessment; never loop.
+
+### Step 6 — Write the report
+
+Use the format below.
+
+## Report format
+
+````
+# Review — <piece>
+
+Verdict: PASS | CONCERN | FAIL
+- Correctness: <PASS/FAIL>
+- Voice: <PASS/CONCERN/FAIL>  (slop: <n>x1 <n>x2 <n>x3 <n>x4 <n>x5)
+- Human perception: <PASS/CONCERN/FAIL>
+- AI perception: <PASS/FAIL/mirror>
+
+## AI perception
+Blind takeaway: <one sentence the cold reader extracted>
+Intended point: <the stated point, or "not supplied">
+<the gap, or "point survived", or the confirm-this-is-your-point prompt>
+
+## Findings (highest severity first)
+1. [voice - severity 4] "<exact quotation>"
+   Why: <reason>
+   Fix: <concrete fix>
+2. [correctness - unsupported] "<exact quotation>"
+   Why: <reason>
+   Fix: <concrete fix>
+...
+
+## Claims to verify by hand
+- "<quoted claim>" — <why it could not be confirmed>
+
+## Density rates (per 1,000 words)
+contrast pivots: <r> | totalizing quantifiers: <r> | disguised lists: <r> | echoes: <r>
+````
+
+Every finding cites a direct quotation from the piece. A finding without a quotation does not ship.
+`````
+
+- [ ] **Step 2: Verify the playbook references all three agents and defines flow, scoring, and format**
+
+Run:
+````bash
+node -e "const fs=require('fs'); const c=fs.readFileSync('stilus/context/reviewing.md','utf8'); for(const a of ['review-correctness','review-voice','review-summary']) if(!c.includes(a)) throw new Error('reviewing.md does not reference '+a); if(!/pass ONLY the piece/i.test(c)) throw new Error('missing blind-only instruction for summarizer'); if(!/Overall verdict:/.test(c)) throw new Error('missing verdict thresholds'); if(!/Merge and dedup/.test(c)) throw new Error('missing dedup step'); if(!/AI perception/.test(c)) throw new Error('missing AI-perception comparison'); if(!/Report format/.test(c)) throw new Error('missing report format'); if(!/single source of truth/i.test(c)) throw new Error('missing SSOT framing'); console.log('OK: reviewing.md references all three agents and defines flow/scoring/format');"
+````
+Expected: `OK: reviewing.md references all three agents and defines flow/scoring/format`.
+
+- [ ] **Step 3: Commit**
+
+````bash
+git add stilus/context/reviewing.md
+git commit -m "$(cat <<'EOF'
+chore - add stilus reviewing.md synthesis playbook
+
+- SSOT for the review flow: intent, fan-out, AI-perception, dedup
+- per-dimension scoring, verdict thresholds, and the report format
+EOF
+)"
+````
+
+---
+
+### Task 5: /stilus:review command
+
+**Files:**
+- Create: `stilus/commands/review.md`
+
+**Interfaces:**
+- Consumes: `stilus/context/reviewing.md` (Task 4) and the three specialist agents (Tasks 1–3).
+- Produces: the `/stilus:review` command — the standalone entry point for reviewing existing or external prose.
+
+- [ ] **Step 1: Create `stilus/commands/review.md`**
+
+````markdown
+---
+description: Review a finished piece of prose — correctness, voice (graded slop), human perception, and whether an AI reader gets the point. Read-only; produces a scored report, never edits. Usage: /stilus:review <file-or-text>
+---
+
+# /stilus:review
+
+Review the prose the user names — a file path or pasted text — and produce a scored report. You change nothing; this is a read-only assessment.
+
+Run the review phase exactly as defined in this plugin's `context/reviewing.md`:
+
+1. **Gather intent** (purpose, audience, intended point). Ask the user in one prompt; if they supply none, proceed with intent unknown.
+2. **Fan out** to the three specialist agents in parallel — `review-correctness`, `review-voice`, and `review-summary` — following `context/reviewing.md`. Pass the blind summarizer ONLY the prose.
+3. **Synthesize:** run the AI-perception comparison, merge and dedup findings, score each dimension, assign the verdict.
+4. **Deliver** the report in the format from `context/reviewing.md`. Never loop back to revise in standalone mode.
+
+The resolved voice profile, if any, comes from the same scan the write skill uses: project `.claude/rules/voice.md`, then user `~/.claude/rules/voice.md`, then this plugin's `rules/voice.md`.
+````
+
+- [ ] **Step 2: Verify the command frontmatter and that it defers to reviewing.md and names the agents**
+
+Run:
+````bash
+node -e "const fs=require('fs'); const c=fs.readFileSync('stilus/commands/review.md','utf8'); const m=c.match(/^---\n([\s\S]*?)\n---/); if(!m) throw new Error('no frontmatter'); if(!/description:/.test(m[1])) throw new Error('command needs a description'); if(!/context\/reviewing.md/.test(c)) throw new Error('command must defer to reviewing.md'); for(const a of ['review-correctness','review-voice','review-summary']) if(!c.includes(a)) throw new Error('command does not name '+a); if(!/ONLY the prose/.test(c)) throw new Error('command must preserve summarizer blindness'); console.log('OK: /stilus:review command valid and thin');"
+````
+Expected: `OK: /stilus:review command valid and thin`.
+
+- [ ] **Step 3: Commit**
+
+````bash
+git add stilus/commands/review.md
+git commit -m "$(cat <<'EOF'
+chore - add /stilus:review standalone command
+
+- thin entry point; defers the whole flow to context/reviewing.md
+- fans out the three review specialists, never edits
+EOF
+)"
+````
+
+---
+
+### Task 6: Docs, whole-plugin validation, and smoke test
+
+**Files:**
+- Modify: `stilus/README.md`
+- Modify: `CLAUDE.md` (Context Ownership table)
+
+**Interfaces:**
+- Produces: documentation consistent with the orchestrated review phase, and a whole-plugin validation gate.
+
+- [ ] **Step 1: Update the Review bullet in `stilus/README.md`**
+
+Change:
+````markdown
+4. **Review** — an independent, read-only judge checks fit, surviving tells, accuracy, and register.
+````
+to:
+````markdown
+4. **Review** — an orchestrated phase: three parallel read-only specialists judge correctness, voice (slop graded 1–5 plus a human-perception read), and AI perception (whether a cold AI reader gets the point), and the orchestrator synthesizes a scored, quotation-grounded report. Run it standalone on any existing prose with `/stilus:review <file-or-text>`.
+````
+
+- [ ] **Step 2: Update the SSOT line in `stilus/README.md`**
+
+Change:
+````markdown
+The slop catalog and shared craft (lead with the point, sentence rhythm, accuracy over precision) live in the `deslop` agent. The voice layer, reviser, and reviewer reference them; they never restate them.
+````
+to:
+````markdown
+The slop catalog and shared craft (lead with the point, sentence rhythm, accuracy over precision) live in the `deslop` agent. The voice layer, reviser, and the review specialists reference them; they never restate them. The review flow and its scoring live once in `context/reviewing.md`, which the `/stilus:review` command and the write skill both run.
+````
+
+- [ ] **Step 3: Add the stilus row to the Context Ownership table in `CLAUDE.md`**
+
+Change:
+````markdown
+| **comitatus** | herdr orchestration | `skills/herdr/SKILL.md` |
+````
+to:
+````markdown
+| **comitatus** | herdr orchestration | `skills/herdr/SKILL.md` |
+| **stilus** | Prose drafting, editing, and review | `agents/deslop.md` (slop catalog), `rules/voice.md` (voice schema), `context/reviewing.md` (review flow + scoring), `agents/review-correctness.md`, `agents/review-voice.md`, `agents/review-summary.md` |
+````
+
+- [ ] **Step 4: Validate the whole review phase — frontmatter, read-only contracts, JSON, docs**
+
+Run:
+````bash
+node -e "
+const fs=require('fs');
+// agents: frontmatter with a name; correct read-only tool sets
+const agents={
+  'stilus/agents/review-summary.md':{name:'review-summary',forbid:/Edit|Write|Grep|Glob/},
+  'stilus/agents/review-voice.md':{name:'review-voice',forbid:/Edit|Write/},
+  'stilus/agents/review-correctness.md':{name:'review-correctness',forbid:/Edit|Write/}
+};
+for(const [f,spec] of Object.entries(agents)){
+  const c=fs.readFileSync(f,'utf8'); const m=c.match(/^---\n([\s\S]*?)\n---/);
+  if(!m) throw new Error(f+': no frontmatter');
+  if(!new RegExp('name:\\\\s*'+spec.name).test(m[1])) throw new Error(f+': wrong name');
+  const t=m[1].match(/tools:.*/)[0]; if(spec.forbid.test(t)) throw new Error(f+': forbidden tool in '+t);
+}
+// command has a description, not a name
+const cmd=fs.readFileSync('stilus/commands/review.md','utf8'); const cm=cmd.match(/^---\n([\s\S]*?)\n---/);
+if(!cm||!/description:/.test(cm[1])) throw new Error('command: missing description frontmatter');
+// reviewing.md ties it together
+const r=fs.readFileSync('stilus/context/reviewing.md','utf8');
+for(const a of ['review-correctness','review-voice','review-summary']) if(!r.includes(a)) throw new Error('reviewing.md missing '+a);
+// marketplace JSON still valid and stilus still registered
+const mk=JSON.parse(fs.readFileSync('.claude-plugin/marketplace.json','utf8'));
+if(!mk.plugins.find(p=>p.name==='stilus')) throw new Error('stilus missing from marketplace');
+// docs updated
+if(!/stilus:review/.test(fs.readFileSync('stilus/README.md','utf8'))) throw new Error('README not updated');
+const cl=fs.readFileSync('CLAUDE.md','utf8');
+if(!/\*\*stilus\*\* \| Prose drafting/.test(cl)) throw new Error('CLAUDE.md ownership row missing');
+console.log('OK: review phase structure, tool contracts, JSON, and docs all valid');
+"
+````
+Expected: `OK: review phase structure, tool contracts, JSON, and docs all valid`.
+
+- [ ] **Step 5: Manual smoke test (requires a live Claude Code session; not automated)**
+
+The deliverables are prompts, so behavior is verified by hand:
+
+1. Reinstall/enable `stilus` from the local marketplace so the new command and agents register.
+2. Run `/stilus:review <path>` on an existing prose file. Confirm:
+   - it asks for purpose/audience/intended point (or proceeds with intent unknown if you decline),
+   - it dispatches `review-correctness`, `review-voice`, and `review-summary`, and they run in parallel,
+   - the `review-summary` dispatch received only the prose (no intent),
+   - the report matches `context/reviewing.md`'s format: a verdict, per-dimension scores, the slop severity distribution, quotation-grounded findings, the claims-to-verify list, and the density rates.
+3. Run it again with the intended point withheld. Confirm the AI-perception section becomes the mirror ("An AI reading this cold took away: … Is that your point?") and is unscored.
+4. Confirm no file was modified (read-only).
+
+Record the outcome in the PR description. If subagent dispatch needs a namespaced agent name on this platform, note the exact form.
+
+- [ ] **Step 6: Commit**
+
+````bash
+git add stilus/README.md CLAUDE.md
+git commit -m "$(cat <<'EOF'
+chore - document stilus review phase
+
+- README: orchestrated review, four dimensions, /stilus:review
+- CLAUDE.md: add stilus Context Ownership row
+EOF
+)"
+````
+
+---
+
+## Known limitations / follow-ups
+
+- **Write-skill integration is deferred.** When the write skill is built (original `2026-06-18-stilus-writing-plugin.md` plan, Task 6), its review step becomes a thin reference to `context/reviewing.md` and dispatches the same three specialists. This plan deliberately ships the standalone review phase first; it is complete and testable on its own.
+- **The reviser loop-back has no target yet.** `context/reviewing.md` describes the one bounded loop-back to the reviser for pipeline FAILs, but the `reviser` agent is built by the original plan (Task 4). Standalone review never loops, so this plan is unaffected.
+- **Severity calibration will drift.** The 1–5 anchors are seeded with examples from deslop's named patterns; expect to tune them once real reviews accumulate.
+
+## Self-Review
+
+**Spec coverage.** Every section of `2026-06-24-stilus-reviewer-redesign-design.md` maps to a task: the three specialists → Tasks 1–3; the four dimensions → review-summary/AI-perception (T1 + T4 Step 3), voice+human (T2), correctness (T3); orchestrated synthesis, AI-perception comparison, dedup, scoring, verdict, report format → T4; the two entry points → the `/stilus:review` command (T5) and the deferred write-skill step (Known limitations); SSOT table → enforced by deslop staying unmodified (Global Constraints) and reviewing.md owning synthesis (T4); the spec's open items → resolved (severity scale in T2, verdict thresholds and dedup in T4, standalone intent capture in T4/T5); docs → T6.
+
+**Placeholder scan.** No "TBD"/"TODO"/"handle edge cases". Every file is given in full. The only non-automated step (T6 Step 5) is labeled manual because prompt behavior has no unit-test harness, matching the rest of stilus.
+
+**Type/name consistency.** Agent names are identical across the agent files, `reviewing.md`, the command, and the validation scripts: `review-correctness`, `review-voice`, `review-summary`. Tool sets are consistent: `review-summary` is `Read` only, `review-voice` is `Read, Grep, Glob`, `review-correctness` adds `WebSearch, WebFetch`; the whole-plugin check in T6 re-asserts each. The report dimensions (Correctness, Voice, Human perception, AI perception) and verdict vocabulary (PASS/CONCERN/FAIL/mirror) are identical between T4's scoring rules and its report format. `context/reviewing.md` is referenced by the same path in T5 and T6.

--- a/docs/superpowers/specs/2026-06-18-stilus-writing-plugin-design.md
+++ b/docs/superpowers/specs/2026-06-18-stilus-writing-plugin-design.md
@@ -1,0 +1,192 @@
+# Stilus — Writing Plugin Design
+
+**Date:** 2026-06-18
+**Status:** Approved design, pending implementation plan
+**Repo:** claude-domestique (new marketplace plugin)
+
+## Overview
+
+Stilus is a new plugin for the claude-domestique marketplace that turns the existing
+`deslop` agent and the patterns behind a personal voice skill into a reusable,
+distributable writing pipeline. It separates two layers of the writing craft that
+overlap heavily today:
+
+- **Subtractive (deslop):** changes how prose is said, never what; output is shorter;
+  voice-neutral. Owns the slop catalog and density budgets.
+- **Additive (voice):** produces prose in a project's own register and persona.
+  Voice-bearing, but supplied by the consuming project rather than baked into the plugin.
+
+The plugin runs these as an adaptive, on-demand pipeline of four phase contracts and
+escalates depth to match what a piece is worth.
+
+## Decisions
+
+These forks were settled during brainstorming and drive the design:
+
+1. **Two layers, generic voice.** Ship deslop as the subtractive base plus a configurable
+   voice layer with no personal specifics baked in.
+2. **Project-extension voice.** A project supplies its voice as a `.claude/rules/voice.md`
+   that `extends: stilus/voice.md`, following the same convention `azure-devops.md` uses to
+   extend `onus/work-items.md`. Scan order is project then user then plugin base, project
+   winning.
+3. **On-demand only.** No hooks, no global injection. The pipeline runs when the user is
+   writing or editing, costing zero context budget otherwise.
+4. **Adaptive escalation.** All four phase contracts exist; the orchestrator picks depth by
+   artifact stakes. Default is write→edit→revise; it drops to write→edit for short or casual
+   text and adds review for published or high-stakes work. Explicit user phrases override.
+5. **Name: stilus.** Latin for the writing instrument and the root of "style"; fits the
+   memento/mantra/onus/artifex family.
+6. **Personal-skill migration is a separate follow-up,** not part of this spec.
+
+## The four phase contracts
+
+Each phase is a worker with an explicit "may / may not" so boundaries stay clean and each
+can run as an isolated subagent.
+
+- **Write** — additive, voice layer. Drafts from facts, notes, or an outline in the project's
+  voice. Owns register and persona. The only phase that originates text. Runs in the
+  orchestrator's own context, where the facts and intent live.
+- **Edit** — subtractive, deslop. Removes slop line by line. Changes how, never what; output
+  is shorter; never reorders the argument or adds. Deliberately cut-biased. This is the
+  existing deslop agent, shipped essentially unchanged.
+- **Revise** — adjudicate and restructure. The counterweight to deslop's aggression: restores
+  load-bearing material that edit cut, fixes the thesis and ordering so the piece leads with
+  the point, and addresses completeness. May change what is said and may reorder. Makes
+  minimal additions and re-cleans anything it adds.
+- **Review** — independent, read-only judge. The prose analog of `/mantra:assess` and code
+  review. Does not edit. Judges against purpose and audience, flags surviving AI tells and
+  density-budget violations, verifies no invented specifics (accuracy over precision),
+  confirms register match. Emits a verdict plus findings; a fail loops back to revise.
+
+### Ordering rationale (edit before revise)
+
+Edit runs before revise because deslop is cut-biased. Edit strips to the skeleton, then
+revise adjudicates on the lean draft and selectively restores. Revise is a selective undo
+plus a structural pass, not a fresh rewrite. The risk that revise reintroduces prose needing
+cleanup is held in check by keeping revise's additions minimal and re-desloping them.
+
+## Component layout
+
+```
+stilus/
+├── .claude-plugin/plugin.json     # manifest (author: Flexion; keywords)
+├── README.md
+├── skills/
+│   └── write/SKILL.md             # Write phase + adaptive orchestrator (entry point;
+│                                  #   auto-triggers on writing/editing tasks)
+├── agents/
+│   ├── deslop.md                  # Edit phase — subtractive. Owns the slop catalog (SSOT)
+│   ├── reviser.md                 # Revise phase — adjudicate + restructure
+│   └── reviewer.md                # Review phase — independent, read-only judge
+├── rules/
+│   └── voice.md                   # Generic voice BASE: profile schema + neutral defaults
+│                                  #   (projects `extends:` this)
+└── context/
+    └── authoring-a-voice.md       # Companion: how to write a project voice profile
+```
+
+The orchestrator skill owns Write and dispatches Edit, Revise, and Review to the three
+subagents as the chosen depth requires. This keeps each phase's editing churn out of the main
+context and keeps Review genuinely independent of the author.
+
+Optional thin commands (`/stilus:deslop <file>`, `/stilus:review`) for explicit single-phase
+invocation are out of scope for v1.
+
+## Voice profile: schema and scan order
+
+`rules/voice.md` is the generic base. It defines the sections a project fills in, with neutral
+defaults and nothing personal:
+
+- **persona/identity** — default: neutral technical author, no personality.
+- **registers** — the concept; a project names its own; default: one neutral analytical register.
+- **preferred/elevated vocabulary** — default: plain.
+- **mode guidance** — email, Slack, document, article skeletons.
+- **additive craft** — register-driven generation, specificity (use the specific number,
+  date, or name), equip the reader to act, analogy as translation.
+
+The base defers two things to deslop by cross-reference, never restating either: the entire
+subtractive and banned-construction catalog, and the shared craft deslop already owns (lead
+with the point, sentence rhythm, accuracy over precision).
+
+A project supplies its voice with a `.claude/rules/voice.md`:
+
+```yaml
+---
+extends: stilus/voice.md
+domain: voice
+---
+```
+
+The orchestrator's preamble scans `.claude/rules` and matches by `domain: voice` or
+`extends: stilus/voice.md`, the same way onus commands match project rules. Scan and
+precedence order:
+
+1. project `.claude/rules/voice.md`
+2. user `~/.claude/rules/voice.md` (optional personal default that follows the user across repos)
+3. plugin `rules/voice.md` base
+
+Project overrides user overrides base.
+
+## Orchestrator behavior
+
+The `write` skill runs the pipeline on demand:
+
+1. **Load voice.** Scan project, user, then base; announce which loaded ("Using voice from
+   `.claude/rules/voice.md`" or "No project voice, using base"), mirroring how onus announces
+   project rules.
+2. **Classify and choose depth.** Infer mode (Slack, email, document, article, white paper)
+   and stakes. Default write→edit→revise; drop to write→edit for short or casual text; add
+   review for published, external, or high-stakes work. Explicit user phrases override
+   ("just draft," "edit only," "full review," "critique only").
+3. **Write** in the resolved voice.
+4. **Edit.** Dispatch deslop; it returns edited text plus its report (cuts per category,
+   before/after density rates).
+5. **Revise** (depth ≥ 3). Dispatch reviser; it adjudicates deslop's cuts, fixes
+   thesis/ordering/completeness, makes minimal additions and re-cleans them.
+6. **Review** (depth = 4). Dispatch reviewer for a verdict plus findings. On fail, loop back
+   to revise once (bounded, to avoid churn). On pass, deliver.
+
+I/O contract matches deslop today: edit a file in place when given a path, return text when
+given raw input, plus a compact provenance line stating which phases ran and what changed.
+
+## Single source of truth
+
+No phase restates another's catalog. This applies the project's existing Context Ownership
+rule to the new plugin.
+
+| Concept | Owner | References it |
+|---|---|---|
+| Subtractive catalog + shared craft (lead with the point, sentence rhythm, accuracy over precision, earned roughness, hidden work) | deslop | reviser, reviewer, voice base |
+| Additive craft (register-driven generation, specificity, equip the reader, analogy) + profile schema (persona, registers, vocabulary, modes) | voice base | write, reviser, reviewer |
+| Whole-piece judgment rubric (purpose/audience, surviving tells, register match) | reviewer | — |
+
+deslop ships essentially as-is. The orchestrator never invokes its standalone drafting path,
+because Write owns drafting.
+
+## Marketplace, versioning, tests
+
+- **Marketplace.** Add a `stilus` entry to `marketplace.json` and a `plugin.json` (author
+  Flexion; keywords: writing, editing, prose, voice, deslop). Start at version 0.1.0, like
+  agent-artifex.
+- **Tests.** None. Like agent-artifex, stilus is pure skills, agents, and markdown with no JS
+  hooks, so there is no Jest suite to add. Revisit only if the optional commands introduce JS.
+- **Docs.** Update `CLAUDE.md` (Context Ownership table, the version-bump plugin list, repo
+  structure) and the marketplace root.
+
+## Out of scope
+
+- Migrating the personal `writing` skill into a `~/.claude/rules/voice.md` profile. Separate
+  follow-up once the plugin is proven.
+- Optional single-phase commands (`/stilus:deslop`, `/stilus:review`).
+- Any always-on hook or global injection.
+
+## Open items to resolve in the implementation plan
+
+- **bump-version.js with a package-less plugin.** The script updates `package.json` and
+  `marketplace.json`, but agent-artifex ships no `package.json`. The plan must confirm whether
+  bump-version handles a package-less plugin or whether stilus seeds its initial 0.1.0 version
+  directly in `marketplace.json`.
+- **Exact reviser and reviewer prompts.** Author these so their contracts hold and so they
+  reference deslop and the voice base rather than restating either.
+- **Depth-classification heuristics.** Pin the signals the orchestrator uses to infer mode and
+  stakes, and the override vocabulary.

--- a/docs/superpowers/specs/2026-06-24-stilus-reviewer-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-24-stilus-reviewer-redesign-design.md
@@ -1,0 +1,226 @@
+# Stilus Reviewer Redesign — Design
+
+**Date:** 2026-06-24
+**Status:** Approved design, pending implementation plan
+**Repo:** claude-domestique (stilus plugin, branch `chore/add-stilus-plugin`)
+**Amends:** `docs/superpowers/specs/2026-06-18-stilus-writing-plugin-design.md` (the Review phase)
+
+## Overview
+
+The original stilus design specified the Review phase as a single read-only agent
+(`agents/reviewer.md`) that judged pipeline output and emitted a PASS/FAIL the
+orchestrator looped back to the reviser. That agent was never built (it was Task 5 of the
+implementation plan). This design replaces it before it is built.
+
+The reviewer becomes a **dual-mode, orchestrated review phase**:
+
+- It works **standalone** on existing or external prose (work the pipeline did not
+  generate), not only on pipeline output.
+- It reviews along **four dimensions**: correctness and content; voice (slop graded on a
+  1–5 severity scale plus a human-perception read); and AI perception (does the point
+  survive when an AI reads and summarizes the piece).
+- It produces a **scored report with a verdict**, where every finding is grounded in a
+  direct quotation from the reviewed document.
+
+The single-agent shape does not survive one requirement: AI perception needs a *blind*
+reader — an agent that judges what the prose conveys without knowing the intended point. A
+subagent cannot spawn its own subagents, and an agent that already knows the intent cannot
+summarize "cold." So review is lifted to an orchestrated phase that fans out to parallel
+specialists and synthesizes their findings in the orchestrator's own context.
+
+## Decisions
+
+These were settled during brainstorming and drive the design:
+
+1. **Review is an orchestrated phase, not a single self-contained agent.** The orchestrator
+   spawns three read-only specialists in parallel, then synthesizes. This resolves the
+   blind-reader constraint, gives each dimension an independent judge, and runs the
+   specialists concurrently.
+2. **Two entry points, both thin.** A new `/stilus:review <file-or-text>` command for
+   standalone review, and the write skill's review step (plus its existing "critique only" /
+   "review this" override path). Both run the identical review flow.
+3. **Three specialists.** correctness; voice-critic (slop grading 1–5 **and**
+   human-perception, kept in one agent because a high-severity slop finding and a "reader
+   bails here" finding are usually the same span); and a blind summarizer.
+4. **Synthesis runs in the orchestrator (main context).** It already holds the intended
+   point, purpose, and audience, and it spawned the specialists. No dedicated synthesizer
+   agent. Synthesis is where the blind-summary-vs-intent comparison (AI perception) happens.
+5. **Shared synthesis logic lives in one context doc.** `stilus/context/reviewing.md` holds
+   the scoring rubric, verdict rules, AI-perception comparison guidance, and report format,
+   so the command and the skill do not duplicate it (the repo's Context Ownership rule).
+6. **deslop is unchanged.** It remains the single source of truth for *what* slop is. The
+   voice-critic detects independently against deslop's catalog and applies a review-specific
+   severity scale on top; it does not restate the catalog.
+7. **Output is a scored report + verdict** with every finding grounded in a direct
+   quotation, its category, severity (1–5 for slop), the reason it is flagged, and a fix.
+8. **Correctness verifies when it can and flags when it cannot.** Internal soundness plus
+   verification against codebase/web where checkable, plus a "claims to verify by hand" list
+   for what the reviewer cannot confirm itself.
+
+## The four review dimensions
+
+### 1. Correctness and content
+
+Owned by the `review-correctness` specialist.
+
+- **Internal soundness.** Claims supported by the piece's own stated evidence; no
+  contradictions or unsupported leaps; the argument holds together.
+- **Verify when possible.** When a claim is checkable from the codebase (claims about this
+  repo) or the web (public facts), verify it and flag what is wrong or unsupported.
+- **Flag for human.** A separate "claims to verify by hand" list for external or factual
+  claims the reviewer cannot confirm itself, so nothing factual passes silently.
+- **Accuracy over precision.** Flag specifics (numbers, dates, names, citations) that read as
+  invented or unverifiable. This rule lives in deslop; the specialist references it.
+
+### 2. Voice — graded slop (1–5)
+
+Owned by the `review-voice` specialist. Detection runs against deslop's catalog (the SSOT);
+the specialist references the catalog and applies the severity scale below.
+
+Each slop finding is scored on a 1–5 scale (full guidance with quoted examples drafted
+inline in the agent):
+
+- **1 — Defensible.** A light tell that is arguable in context (e.g., one stray "robust").
+  Worth noting, low priority.
+- **2 — Minor.** Cut on sight, but harmless to meaning. A single filler word, a mild hedge.
+- **3 — Noticeable.** A clear machine habit; a reader senses "an AI wrote this." A relief
+  structure, a participial summary tail, a tricolon riding for rhythm.
+- **4 — Degrading.** Actively erodes trust or clarity; often multiple stacked tells, booster
+  register, or a posture declarative standing in for a fact.
+- **5 — Reading-stopping.** Empty performance, a wall of words, or meaninglessness a reader
+  bounces off — the point buried or absent, density budgets blown.
+
+The specialist also reports the per-1,000-word density-budget rates deslop already defines
+(contrast pivots, totalizing quantifiers, disguised lists, echoes).
+
+### 3. Human perception
+
+Also owned by `review-voice` (same agent, because the spans overlap with slop findings).
+
+Will a human reader keep reading, or bail? The read covers:
+
+- **Wall of text** — paragraphs or sentences so long the reader skips them.
+- **Unnecessary jargon** — undefined terms or insider shorthand the audience will not parse.
+- **Meaninglessness** — filler that signals value without delivering it; the reader gets
+  nothing and stops.
+- **Buried or absent point** — the reader who stops early leaves without the takeaway.
+
+Reported as a "will they keep reading?" read with the specific spans that cause drop-off.
+
+### 4. AI perception (round-trip)
+
+The novel dimension. Computed during synthesis from the blind summarizer's output.
+
+- The `review-summary` specialist sees **only the prose** — no intended point, no rubric — and
+  reports what it took away: the main point and the key claims it extracted.
+- Synthesis compares that blind summary against the intended point:
+  - **Known intent** (pipeline mode, or the user stated the point): does the point survive
+    the round-trip? Where the AI's takeaway diverges from intent, the prose failed to carry
+    the point to a machine reader; flag the gap.
+  - **Unknown intent** (standalone external prose): surface what the AI extracted as the
+    point and ask the user to confirm it matches their intent — a mirror, not a pass/fail.
+
+This tests whether the point gets across to an AI agent that later analyzes or summarizes the
+piece — increasingly the real downstream reader.
+
+## Architecture
+
+### Flow
+
+Identical for both entry points:
+
+1. **Gather intent.** The orchestrator establishes the piece's purpose, audience, and
+   intended point — from the pipeline context, from the user, or by asking. In standalone
+   mode on external prose it may proceed with intent unknown (see AI perception).
+2. **Fan out.** Spawn the three read-only specialists in parallel on the same target.
+3. **Synthesize.** In the orchestrator's context: run the AI-perception comparison, merge the
+   three findings sets (dedup overlapping spans), score each dimension, and assign the
+   overall verdict.
+4. **Emit / route.** Standalone: deliver the report. In-pipeline: a failing verdict drives
+   one bounded loop-back to the reviser, then deliver.
+
+### Specialists (parallel, read-only)
+
+| Agent | Dimension(s) | Tools |
+|---|---|---|
+| `agents/review-correctness.md` | Correctness and content | `Read, Grep, Glob, WebSearch, WebFetch` |
+| `agents/review-voice.md` | Voice (slop 1–5) + human perception | `Read, Grep, Glob` |
+| `agents/review-summary.md` | Blind summary (feeds AI perception) | `Read` |
+
+None has `Edit` or `Write`. The summarizer is deliberately starved of context: only the prose
+and an instruction to report what it conveys.
+
+### Component layout
+
+```
+stilus/
+├── agents/
+│   ├── deslop.md              # unchanged — slop-catalog SSOT
+│   ├── reviser.md             # unchanged — revise phase
+│   ├── review-correctness.md  # NEW — correctness & content specialist
+│   ├── review-voice.md        # NEW — slop grading (1–5) + human perception
+│   └── review-summary.md      # NEW — blind summarizer
+├── commands/
+│   └── review.md              # NEW — /stilus:review standalone entry
+├── context/
+│   ├── authoring-a-voice.md   # unchanged
+│   └── reviewing.md           # NEW — synthesis: scoring, verdict, AI-perception, report format
+├── rules/
+│   └── voice.md               # unchanged — register SSOT
+└── skills/
+    └── write/SKILL.md         # MODIFIED — review step becomes fan-out + synthesis
+```
+
+This replaces the single `agents/reviewer.md` that the original plan's Task 5 would have
+built, and reshapes Task 6's review step.
+
+## Output: the scored report
+
+A review produces:
+
+- **Per-dimension scores** — correctness, voice (with the slop severity distribution),
+  human perception, AI perception.
+- **An overall verdict** — drives the one bounded loop-back in pipeline mode; in standalone
+  mode it is the assessment.
+- **A prioritized findings list.** Every finding carries:
+  - a **direct quotation** from the reviewed document (the grounding),
+  - its category,
+  - severity (1–5) for slop findings,
+  - *why* it is flagged (slop / incorrect / jargon / buried point / unverified claim),
+  - a concrete fix.
+- **A "claims to verify by hand" list** from the correctness specialist.
+- **The AI-perception read** — the blind summary, and how it compares to the intended point
+  (or the confirm-this-is-your-point mirror in standalone mode).
+
+## Single source of truth
+
+| Concept | Owner | References it |
+|---|---|---|
+| Subtractive slop catalog + density budgets + accuracy-over-precision | `deslop` | review-voice, review-correctness |
+| Register / persona / voice schema | `rules/voice.md` | review-voice |
+| 1–5 slop severity scale + human-perception rubric | `review-voice` | — |
+| Correctness rubric (internal soundness, verify, flag-for-human) | `review-correctness` | — |
+| Synthesis: scoring, verdict, AI-perception comparison, report format | `context/reviewing.md` | `/stilus:review` command, write skill |
+
+No specialist restates another's catalog. The review-specific rubrics (severity, perception,
+correctness, synthesis) are new and owned where listed.
+
+## Out of scope
+
+- Changes to `deslop.md`, `reviser.md`, `rules/voice.md`, or the write/edit/revise phases
+  beyond the write skill's review step.
+- A dedicated synthesizer subagent (synthesis runs in the orchestrator).
+- Splitting voice-slop and human-perception into separate agents.
+- Any always-on hook or global injection (stilus stays on-demand).
+
+## Open items to resolve in the implementation plan
+
+- **Severity-scale calibration.** Draft the 1–5 guidance with two or three quoted examples per
+  level, anchored to deslop's named patterns, so grading is reproducible across runs.
+- **Synthesis verdict thresholds.** Pin how per-dimension scores roll up to PASS/FAIL (in
+  pipeline) and what triggers the single reviser loop-back.
+- **Standalone intent capture.** Define exactly what the `/stilus:review` command asks for
+  (purpose, audience, intended point) and how it behaves when the user supplies none.
+- **Dedup rule for overlapping spans.** Specify how synthesis merges a span flagged by both
+  voice-critic (as slop) and correctness (as unsupported), so it appears once with both lenses.
+- **CLAUDE.md Context Ownership.** Add the review-phase row reflecting the new owners above.

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -13,7 +13,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const PLUGINS = ['mantra', 'memento', 'onus', 'agent-artifex', 'comitatus'];
+const PLUGINS = ['mantra', 'memento', 'onus', 'agent-artifex', 'comitatus', 'stilus'];
 const VERSION_TYPES = ['patch', 'minor', 'major'];
 
 function parseArgs() {

--- a/stilus/.claude-plugin/plugin.json
+++ b/stilus/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "stilus",
+  "description": "Stilus — adaptive writing pipeline: draft in a project's voice, then remove AI slop. Write, edit, revise, and review prose with deslop as the subtractive base and a project-supplied voice layer.",
+  "author": {
+    "name": "Flexion"
+  },
+  "repository": "https://github.com/flexion/claude-domestique",
+  "homepage": "https://github.com/flexion/claude-domestique",
+  "license": "MIT",
+  "keywords": [
+    "writing",
+    "editing",
+    "prose",
+    "voice",
+    "deslop",
+    "flexion"
+  ]
+}

--- a/stilus/.claude-plugin/plugin.json
+++ b/stilus/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stilus",
-  "description": "Stilus — adaptive writing pipeline: draft in a project's voice, then remove AI slop. Write, edit, revise, and review prose with deslop as the subtractive base and a project-supplied voice layer.",
+  "description": "Stilus — writing tools for Claude Code: remove AI slop with the deslop agent, write in a project's voice, and review finished prose along correctness, voice, and AI-perception dimensions.",
   "author": {
     "name": "Flexion"
   },

--- a/stilus/README.md
+++ b/stilus/README.md
@@ -1,0 +1,37 @@
+# stilus
+
+Adaptive writing pipeline for Claude Code. Draft prose in a project's voice, then remove AI slop.
+
+Latin for the writing instrument and the root of "style."
+
+## What it does
+
+`stilus` runs prose through up to four phases, escalating depth to match what a piece is worth:
+
+1. **Write** — draft in the project's voice (additive).
+2. **Edit** — remove slop line by line with the `deslop` agent (subtractive; changes how, never what).
+3. **Revise** — adjudicate deslop's cuts and fix structure so the piece leads with the point.
+4. **Review** — an independent, read-only judge checks fit, surviving tells, accuracy, and register.
+
+A Slack message gets write → edit. A document gets write → edit → revise. A white paper gets all four.
+
+## On-demand only
+
+`stilus` ships no hooks and injects no global context. The `write` skill triggers when you are drafting or editing prose to send or publish, and costs nothing otherwise.
+
+## Voice profiles
+
+`stilus` carries no personality. A project supplies its own voice in `.claude/rules/voice.md`:
+
+```yaml
+---
+extends: stilus/voice.md
+domain: voice
+---
+```
+
+Fill in the sections from `rules/voice.md`. A personal default can live at `~/.claude/rules/voice.md` and follows you across repos. Precedence: project over user over the plugin base. See `context/authoring-a-voice.md`.
+
+## Single source of truth
+
+The slop catalog and shared craft (lead with the point, sentence rhythm, accuracy over precision) live in the `deslop` agent. The voice layer, reviser, and reviewer reference them; they never restate them.

--- a/stilus/README.md
+++ b/stilus/README.md
@@ -11,7 +11,7 @@ Latin for the writing instrument and the root of "style."
 1. **Write** — draft in the project's voice (additive).
 2. **Edit** — remove slop line by line with the `deslop` agent (subtractive; changes how, never what).
 3. **Revise** — adjudicate deslop's cuts and fix structure so the piece leads with the point.
-4. **Review** — an independent, read-only judge checks fit, surviving tells, accuracy, and register.
+4. **Review** — an orchestrated phase: three parallel read-only specialists judge correctness, voice (slop graded 1–5 plus a human-perception read), and AI perception (whether a cold AI reader gets the point), and the orchestrator synthesizes a scored, quotation-grounded report. Run it standalone on any existing prose with `/stilus:review <file-or-text>`.
 
 A Slack message gets write → edit. A document gets write → edit → revise. A white paper gets all four.
 
@@ -34,4 +34,4 @@ Fill in the sections from `rules/voice.md`. A personal default can live at `~/.c
 
 ## Single source of truth
 
-The slop catalog and shared craft (lead with the point, sentence rhythm, accuracy over precision) live in the `deslop` agent. The voice layer, reviser, and reviewer reference them; they never restate them.
+The slop catalog and shared craft (lead with the point, sentence rhythm, accuracy over precision) live in the `deslop` agent. The voice layer, reviser, and the review specialists reference them; they never restate them. The review flow and its scoring live once in `context/reviewing.md`, which the `/stilus:review` command and the write skill both run.

--- a/stilus/README.md
+++ b/stilus/README.md
@@ -1,23 +1,20 @@
 # stilus
 
-Adaptive writing pipeline for Claude Code. Draft prose in a project's voice, then remove AI slop.
+Writing tools for Claude Code: remove AI slop, write in a project's voice, and review finished prose.
 
 Latin for the writing instrument and the root of "style."
 
 ## What it does
 
-`stilus` runs prose through up to four phases, escalating depth to match what a piece is worth:
+`stilus` ships three pieces today — the `deslop` editor, a project voice layer, and a standalone review phase. A full drafting pipeline is planned (see [Roadmap](#roadmap)).
 
-1. **Write** — draft in the project's voice (additive).
-2. **Edit** — remove slop line by line with the `deslop` agent (subtractive; changes how, never what).
-3. **Revise** — adjudicate deslop's cuts and fix structure so the piece leads with the point.
-4. **Review** — an orchestrated phase: three parallel read-only specialists judge correctness, voice (slop graded 1–5 plus a human-perception read), and AI perception (whether a cold AI reader gets the point), and the orchestrator synthesizes a scored, quotation-grounded report. Run it standalone on any existing prose with `/stilus:review <file-or-text>`.
-
-A Slack message gets write → edit. A document gets write → edit → revise. A white paper gets all four.
+- **Edit** — remove slop line by line with the `deslop` agent (subtractive; changes how, never what). `deslop` can also draft clean prose from facts or critique a draft without editing it.
+- **Voice** — a project supplies its own register in `.claude/rules/voice.md`, extending the plugin's neutral base. See [Voice profiles](#voice-profiles).
+- **Review** — an orchestrated phase: three parallel read-only specialists judge correctness, voice (slop graded 1–5 plus a human-perception read), and AI perception (whether a cold AI reader gets the point), and the orchestrator synthesizes a scored, quotation-grounded report. Run it on any prose with `/stilus:review <file-or-text>`.
 
 ## On-demand only
 
-`stilus` ships no hooks and injects no global context. The `write` skill triggers when you are drafting or editing prose to send or publish, and costs nothing otherwise.
+`stilus` ships no hooks and injects no global context. Its agents and the `/stilus:review` command run only when you invoke them, and cost nothing otherwise.
 
 ## Voice profiles
 
@@ -34,4 +31,8 @@ Fill in the sections from `rules/voice.md`. A personal default can live at `~/.c
 
 ## Single source of truth
 
-The slop catalog and shared craft (lead with the point, sentence rhythm, accuracy over precision) live in the `deslop` agent. The voice layer, reviser, and the review specialists reference them; they never restate them. The review flow and its scoring live once in `context/reviewing.md`, which the `/stilus:review` command and the write skill both run.
+The slop catalog and shared craft (lead with the point, sentence rhythm, accuracy over precision) live in the `deslop` agent. The voice layer and the review specialists reference them; they never restate them. The review flow and its scoring live once in `context/reviewing.md`, which the `/stilus:review` command runs.
+
+## Roadmap
+
+The intended full pipeline escalates depth to match what a piece is worth: **Write** (draft in the project's voice) → **Edit** (`deslop`) → **Revise** (adjudicate deslop's cuts and fix structure) → **Review**. The **Write** skill (the pipeline's orchestrator entry point) and the **Revise** phase (the `reviser` agent) are planned; today stilus ships the **Edit**, **Voice**, and **Review** pieces above.

--- a/stilus/agents/deslop.md
+++ b/stilus/agents/deslop.md
@@ -1,0 +1,116 @@
+---
+name: deslop
+description: Use to remove AI slop from prose or to draft prose without it; relief-structure sentences, empty openers and closers, restatement, padding, and the construction-level tells. Give it a file path to edit in place, raw text to rewrite, or facts to draft from. Works in two phases, critique then edit, and can produce the critique alone for review before the file changes. Reports what it cut or what it avoided.
+tools: Read, Edit, Write, Grep, Glob
+---
+
+You remove AI slop from prose, and you write prose that has none. You change how things are said, never what is said. You produce neutral statement, not persuasion: the chest-thump, the exclusion climax, and the three-part cadence sell a claim that the facts should carry alone, so you cut the selling and leave the claim standing. Facts, numbers, claims, citations, code, links, and direct quotations survive every edit untouched.
+
+## The operation
+
+Your one operation is to distill: at every scale, from word and clause to sentence, paragraph, and section, cover the unit and ask whether it adds information the reader does not already have. If it adds none, cut it. That test is the whole job. The patterns catalogued below are only the shapes slop most often takes, listed to speed recognition; the test defines slop, not the catalog, so apply it to constructions no rule names rather than waiting for a label to match. Beyond catching unnamed instances, hunt for unnamed patterns: any recurring shape that reads as machine habit though no rule names it. Recurrence is the signal: when the same uncatalogued shape appears three or more times, abstract it into a pattern, name it, state its shape and the fact-test that exposes it, and treat it like any catalogued tell. Report every pattern you find this way, so the catalog grows from what the prose reveals.
+
+The test runs at every scale, and a piece can pass it on every sentence and still fail it whole: clean sentences that together say more than the information is worth, bury the point, or perform thoroughness. So ask it large too: would the reader lose any fact if this ran half as long? Match length to what the information is worth, never to how much could be said. Lead with the point, so a reader who stops after the first sentence still has it. Do not pad to seem rigorous; if the reader wants more, the reader asks.
+
+## What you remove, and never write
+
+These are the frequent shapes of the one defect, grouped by what they share. Recognize them fast, but cut by the test in The operation, not by the label. The fix for nearly all of them is the same: cover the unit, and if no fact is lost, cut it.
+
+### Edge slop and restatement
+
+One defect, a unit that adds no information, clusters at the edges of every unit and wherever a fact is stated twice. At the edges it is scale-invariant. Leading: a clause that frames before the sentence says anything, a sentence that previews its paragraph, a paragraph that announces its section. Trailing: a clause that only restates its sentence, a sentence that recaps its paragraph, a paragraph that sums up its section. So scan by scale and edge: for each section read its first and last paragraph, for each paragraph its first and last sentence, for each sentence its first and last clause. Open each unit on content, close it on whatever advanced the content, and drop whatever only frames, previews, recaps, repeats, or reassures. The named faces:
+
+**The relief structure.** A statement, then a colon or comma, then a second clause that restates the first with emphasis instead of adding information: repetition wearing rhythm. Cover the second half; nothing lost means delete it, and if the second half carries the content while the first only sets it up, keep the second.
+- Slop: "The test suite is the safety net: it catches problems before they ship." (the second clause defines the metaphor; one of them goes)
+- Not slop: "The pipeline deploys weekly: build, test, scan, swap." (the second half is new information)
+
+**Restatement at a distance.** One fact appears once. When a later sentence says an earlier thing in new words, delete the weaker occurrence. "In other words," "put differently," "that is to say," and "simply put" always mark a deletion site; unmarked restatements are the same defect without the confession.
+
+**Empty openers and closers.** Delete anything before the first content sentence that frames, announces, or sets scene, and any summary, restated thesis, or wind-down after the last. At section scale, a paragraph that previews and a paragraph that recaps both go. Closers that zoom out to universal significance ("continues to resonate," "is what it is all about") and aphoristic closers that gesture wider than the argument both die; end on a concrete particular, or stop one sentence earlier.
+
+**The participial summary tail.** A present-participle clause tacked onto a finished sentence to grade what it just said rather than add a fact: "the system scales to four mills, demonstrating its flexibility," "we backfilled the tests, underscoring our rigor," "the adapter isolates each source, ensuring clean boundaries." The verbs are a near-closed set worth grepping: demonstrating, highlighting, underscoring, showcasing, reflecting, ensuring, allowing, enabling, emphasizing, illustrating. Cut the clause; if it carries a real consequence rather than a grade, make it its own sentence with an actor ("so a fifth mill adds only an adapter").
+
+### Cramming: content restructured to look like analysis
+
+**The disguised list.** A claim, then a colon or comma, then three or more items hung off it: a bullet list reset as prose to pass for analysis. The items can be clauses with finite verbs ("agents work in repositories set up to teach them, their output passes the same merge gates as hand-written code including AI code review, and the multiplier is measured"), bare noun phrases, or a from-X-through-Y-to-Z escalation ("from read-only lookups through preview-and-confirm schedule changes to a blocked destructive tier"). The tell is recurrence: when most paragraphs open "thesis: a, b, and c," the shape is the fingerprint. If a reader would scan the items and pick among them, make an honest list; otherwise cut to the one or two that earn the sentence and write them with subjects and verbs. Budget: see Density tells.
+
+**Overloaded sentences.** One sentence carrying four or more separate facts behind stacked colons, semicolons, appositives, and "with" tails, so the reader cannot hold the thread: "Schedule order exists only as array position: the drag handler splices an array and writes no field, and the grouping logic trusts adjacency without ever sorting, so the first database read without an ORDER BY fragments the schedule; executed against the full snapshot, a shuffled read renders 9 sequences as 137 groups." Count the independent facts; past three, split at the joints. A long sentence earns its length by building to one point, not by warehousing five.
+
+**Truncated-passive chains.** A comma series, usually after a colon, where two or more items open with a noun phrase and a bare past participle with no auxiliary: "code transformed to testable shape, tests backfilled, the pipeline hardened, the infrastructure made observable." Passive voice with even the "is" deleted, a changelog wearing commas with no one acting. The fix names the actor once and lets finite verbs ride the series: "the team transforms code to testable shape, backfills tests, hardens the pipeline, and makes the infrastructure observable." Items with finite or active verbs are not the pattern.
+
+### Performed stance and tone: a posture in place of a fact
+
+**Posture declaratives.** A short, confident sentence that announces a virtue rather than stating a fact: decisiveness, seriousness, thoroughness, realness, commitment. "We keep the application and take it to production." "We treat both sections as binding." "We proved the migration process on this code, not a stand-in." "This team carries the AI product expertise the assistant requires." Cut the sentence and ask what fact is lost; if only the stance is lost, cut it, and where it carries a fact, keep the fact and drop the flourish.
+
+**Booster register.** The relentlessly positive tone that praises what it describes and never doubts it: every approach strong, every result exciting, every tradeoff a win. Uniform positivity is a register tell and the house style of sales copy, which neutral technical writing is not. State what a thing does and what it costs. Cut the praise adjectives (powerful, seamless, robust, exciting, game-changing) and the reassurance that nothing can go wrong; where a real risk or limit exists, name it.
+
+**Both-sidesing.** The reflexive refusal to take a position: "while there are challenges, there are also opportunities," "it is important to consider multiple perspectives," "there are valid arguments on both sides." It performs balance while committing to nothing. When the writer has a position, state it; when a tradeoff is real, name both sides and say which one wins here and why.
+
+### Rhetorical frames: shape added in place of content
+
+**Banned constructions.** "Not just X, it is Y" in any punctuation, always; if the contrast matters, write it directly. "X is not Y. It is Z." at most once per piece and never as opener, thesis, or closer; if the assertion stands alone, drop the negation half. Rhetorical questions as transitions. Label scaffolds ("What we know: X. What changed: Y."), a list wearing prose punctuation; write the sentences.
+
+**The rule of three.** The tricolon is a loud cadence tell: three parallel items where two would inform and the third rides for rhythm, whether an escalating triad, a three-adjective stack, or a three-clause parallel. Test the third item; if it adds no fact the first two lack, cut to two. "Not APEX, not Oracle Forms, and not a demo" is three for rhythm; "typed, scoped, individually tested" keeps all three because each names a distinct property.
+
+### Empty words: filler that signals value or rhythm without adding information
+
+**Performative tics.** A tic is the cheapest phrase that signals a value instead of doing it: respect complexity by handling it, show analysis by naming what breaks, defer by giving a real date. A sampler across the families: leverage, circle back, reach out, touch base, low-hanging fruit, at the end of the day, going forward, delve, tapestry, navigate the complexities, it is important to note, it is worth noting, the key takeaway, load-bearing, stands as, meticulously, transforms X into Y, speaks to, captures the essence of. The verb "land" in every form (a change lands, view logic landing in modules, a deferral lands in the slice) is filler dressed as motion that hides a plainer verb or the actor who should be named. Formulaic transitions ("moreover," "furthermore," "additionally," "in conclusion," "importantly") are tics when they only announce a turn; keep one only where it marks a real logical move. When a phrase could appear in any competent generalist's email, write the plain sentence instead.
+
+**Style words.** A corpus-validated set of flowery words that spiked across LLM output after 2023 and recur regardless of subject (Kobak et al., Science Advances 2025; Juzek and Ward, COLING 2025). The excess is mostly verbs, then adjectives, so hunt those first. Verbs: delve, showcase, underscore, boast, surpass, unlock, comprehend, align. Adjectives: intricate, pivotal, nuanced, meticulous, commendable, groundbreaking, crucial. Nouns: realm, tapestry (academic registers add findings, reliance, generalizability). One instance is not proof; recurrence is the tell, and the set drifts as models change.
+
+**Padding.** Throat-clearing, hedges that bound no real uncertainty, intensifiers without measurement ("very," "significantly," "robust"), double verbs ("serves to provide"), synonymic doublets where two near-synonyms ride an "and" and one would do ("clear and concise," "robust and scalable," "comprehensive and detailed"), filler ("really," "actually," "basically," "just," "simply"), and "in order to" for "to."
+
+**Disguised intensifiers.** A modifier that reads as a concrete fact but adds emphasis, the crisp shape (often a hyphen) hiding it: "day-one asks," "the concrete reference," "a clean consumer-facing API," "uniform, coherent canonical data," "a production-bound codebase," "what is genuinely broken." Swap the modifier for its literal meaning or delete it; if no fact is lost, it was sheen ("day-one asks" becomes "the asks we make at the start"). A modifier that names a verifiable property stays: drop "zero-downtime" and the SLA is gone, drop "deterministic," "disposable," "role-based," or "non-UTC" and a real fact is gone. The deletion test decides, not the hyphen.
+
+### Two that stand alone
+
+**Missing actors.** Agentless dodges ("it has been argued," "mistakes were made"), "there is" and "there are" when a real subject exists, nominalizations hiding the verb ("made a decision" for "decided"), and the shape where a thing performs a person's action ("the report goes out tomorrow" for "the team sends the report tomorrow"). A frequent variant gives a system or abstraction a mind: "the grouping logic trusts adjacency," "the conversion surfaced two more instances," "the views commit to a number," "delivery touches each view." Code and processes do not trust, decide, prove, commit, or surface; name the human actor, or give the mechanism a mechanical verb ("the grouping starts a new group whenever the seq key changes").
+
+**Opaque cleverness.** A phrase that reads sharp but whose literal meaning a reader cannot restate: "before the rest of the views commit to a number," "the second chosen because it exercises seams the first does not." Say in plain words what it literally claims; if you cannot, the writer could not either, so write the plain claim or cut the phrase. Clarity outranks cadence.
+
+## What you protect when writing
+
+**Accuracy over precision.** Never invent a specific. A vague-but-true claim beats a precise-but-false one; if a number, date, or name rests on feel rather than verification, write around it or verify it.
+
+**Sentence rhythm.** Vary length aggressively. Several sentences in a row at 15 to 25 words is the AI signature; break one into a fragment or a punch, let another build long. The variance reads human because it is.
+
+**Earned roughness.** Smoothness is a tell. When the rough construction is the precise one, keep it rough; do not sand a sentence into the shape every model produces.
+
+**Work stays hidden.** Prose states the answer; it does not enumerate rejected alternatives or walk the reasoning. (Your report is the sanctioned exception.)
+
+## Density tells
+
+The instance rules above miss the defect that lives in aggregate: constructions that pass inspection one at a time and still fingerprint the prose by recurrence. Measure these across the whole piece before editing (grep and count), and enforce budgets:
+
+- **Contrast pivots** (", not X", ", never X", "rather than"): budget one per 500 words. Over budget, keep the instances whose negated half a reader could genuinely hold, and rewrite the rest as positive statements. Defining things by exclusion is the habit being broken; the positive claim usually stands alone. Treat ", never X" as the highest-suspicion variant and cut on sight unless the negated half is a real alternative the reader would otherwise assume: "never" almost always overclaims for rhythm, and the positive statement carries the point without it. A standalone fragment built only of negation ("Not APEX, not Oracle Forms, and not a demo") and a bare "not a stand-in" tacked onto a finished claim are the loudest cases: they carry emphasis and no fact, so cut them first.
+- **Totalizing quantifiers** ("every", "all", "always"): above roughly 2 per 1,000 words, the genuine commitments blur into the rhetorical ones. Keep "every" only where the totality is itself the claim; elsewhere name the actual scope or drop the quantifier.
+- **Echoes and low lexical diversity**: "real" as an adjective and "the same" as parallelism. Once context establishes the contrast or the parallel, the bare noun carries it; keep the first occurrence, cut the echoes. Two cousins ride the same budget. A vague qualifier repeated as a motif ("day-one," "early") is an echo whether or not any single use is defensible; keep the one that names a real gate and cut the rest. A term that carries a real fact but has gone cliche through overuse ("cross-functional") keeps only its load-bearing use, where the fact it names is the point, and loses the repetitions; the governing test there is wear, not redundancy. The wider defect detectors measure directly is low lexical diversity: one sentence-opener repeated down a paragraph, or a single collocation reused where a writer would reach for a variant. Vary the opener and the phrase, or cut the repeat.
+- **Inline justification**: a "because" on every claim reads as relentless self-defense. Where the reason is obvious or already given, assert.
+- **Disguised lists** (a claim, then a colon or comma, then three or more enumerated items): budget one per paragraph. Above it, the prose is a status report in sentence clothing. Keep the enumeration only where the items are genuinely a set the reader picks among; collapse the rest into sentences, or cut to what carries weight.
+
+Report the per-1,000-word rates before and after for each budgeted pattern. Named rules and quoted standards are exempt from the budgets and from edits ("no direct EBS write," "never down, never wrong, always healthy, fast").
+
+## Bias
+
+When unsure whether to cut, cut. Too little beats too much. When editing, never add sentences, transitions, or summaries; the output is shorter than the input. Bullets only when the content is genuinely list-shaped; prose is the default. This and the disguised-list rule branch on the same test and do not conflict: genuinely list-shaped content becomes an honest list, the rest becomes sentences, and a colon-dump is neither yet, so route it to whichever it actually is. Formatting carries the same tells: heavy bold, a header over every short stretch, emoji, and reflexive listification are markdown habits that read as machine output; strip them to plain prose unless the document genuinely needs navigation.
+
+## Voice rules that hold through every edit and draft
+
+No em dashes. No contractions. Active voice with named actors. Plain words. When editing, these apply to your rewrites; if the source violates them outside the spans you edit, leave those violations alone unless asked.
+
+## How you work
+
+Deslopping is two phases, critique then edit. Say which you are doing.
+
+**Critique (phase one).** Read the target and produce the analysis without changing the file. List each flagged span with its category and the fix, name the macro read (wordiness, tone, paragraph structure, whether the point leads or is buried), report the before density rates for the budgeted patterns, and quote the candidates you weighed and left alone. This is a standalone deliverable: when the request asks for a critique, a review, or an analysis, or says to hold edits, stop here and change nothing.
+
+**Edit (phase two).** Apply the critique's fixes in place with Edit, or rewrite raw text from the prompt. Touch nothing inside code blocks, footnote citation lines, mermaid blocks, or direct quotations. Report word count before and after, cuts per category, the three worst offenders quoted before and after, and the after density rates. When asked to deslop a file outright, run phase one then phase two and show the critique in the report so the edit is auditable.
+
+**Drafting.** When given facts, notes, or an outline to write from, write the prose under every rule above, then run your own removal pass on the draft before returning it. Report after the draft: the tells you caught in your own pass, and any specific you declined to invent.
+
+## What you never do
+
+- Change a fact, weaken a claim, or drop a citation.
+- Rewrite for taste beyond the rules above.
+- Expand anything while editing.
+- Declare prose clean without quoting the candidates you considered and rejected.

--- a/stilus/agents/review-correctness.md
+++ b/stilus/agents/review-correctness.md
@@ -1,0 +1,50 @@
+---
+name: review-correctness
+description: Correctness critic for the stilus review phase. Give it a piece of prose (and any context about the codebase or domain it concerns). It checks internal soundness — claims supported by the piece's own evidence, no contradictions or unsupported leaps — verifies checkable claims against the codebase and the web, and returns a separate "claims to verify by hand" list for what it cannot confirm. Read-only; returns quotation-grounded findings, not edits.
+tools: Read, Grep, Glob, WebSearch, WebFetch
+---
+
+You judge whether a piece is correct and whether its content holds together. You do not edit.
+
+## What you receive
+
+- The piece: a file path or raw text.
+- Whatever context exists about the codebase, repo, or domain the piece concerns.
+
+## What you do
+
+### 1. Internal soundness
+
+Read the argument as a skeptic. Flag:
+
+- Claims the piece asserts but does not support with its own stated evidence.
+- Contradictions — two passages that cannot both be true.
+- Unsupported leaps — a conclusion that does not follow from what precedes it.
+- Missing content the reader needs to act on the piece's own terms.
+
+### 2. Verify what is checkable
+
+When a claim is verifiable, verify it:
+
+- **About this repo or codebase** — use Read, Grep, and Glob to confirm. Flag claims the code contradicts (a named file that does not exist, a described behavior the code does not have).
+- **Public facts** — use WebSearch and WebFetch to confirm names, dates, figures, and citations where a quick check settles it. Flag what is wrong.
+
+### 3. Flag for human
+
+Build a separate "claims to verify by hand" list: external or factual claims you cannot confirm yourself (private data, unpublished facts, anything a search does not settle). List them so nothing factual passes silently.
+
+### 4. Accuracy over precision
+
+Flag specifics — numbers, dates, names, citations — that read as invented or unverifiable. This rule lives in the deslop agent (`stilus/agents/deslop.md`); reference it, do not restate it. A vague-but-true claim beats a precise-but-false one.
+
+## Contracts
+
+- Read-only. You never edit the piece.
+- Ground every finding in a direct quotation from the piece. No quotation, no finding.
+- Distinguish what you verified and disproved from what you could not check. Never present an unverified claim as confirmed either way.
+
+## What you return
+
+1. Soundness findings, each with: the quoted span, the category (unsupported / contradiction / leap / missing), why, and the fix.
+2. Verification results: the claims you checked, what you found, and the source.
+3. The "claims to verify by hand" list.

--- a/stilus/agents/review-summary.md
+++ b/stilus/agents/review-summary.md
@@ -1,0 +1,31 @@
+---
+name: review-summary
+description: Blind summarizer for the stilus review phase. Give it ONLY a piece of prose (a file path or raw text) and nothing else — no intended point, no purpose, no rubric. It reports what a cold reader takes away: the point in one sentence, the key claims, a two-sentence "what was this about", and where it stalled. Used to test AI perception — whether the writing's point survives an independent machine read.
+tools: Read
+---
+
+You are a cold reader. You receive a piece of prose and nothing else: no statement of what it is for, no intended takeaway, no checklist. Report only what the text itself conveys to you on a first read.
+
+## What you receive
+
+A file path to read, or raw text. Nothing about its purpose, audience, or intended point. If any context about intent reached you, ignore it; your value is that you did not know.
+
+## What you do
+
+Read the piece once, as a reader who will act on it or pass it along. Then report:
+
+1. **The point, in one sentence.** What is this piece actually saying? If you cannot find a single point, say so — that is itself the finding.
+2. **Key claims.** The three to six load-bearing claims you would carry away.
+3. **What you would tell someone.** If a colleague asked "what was that about?", your two-sentence answer.
+4. **Where you stalled.** Any passage you had to reread, skip, or could not parse. Name the span.
+
+## Contracts
+
+- Read-only. You never edit.
+- Do not judge quality, grade slop, or check facts. You only report what got through to you.
+- Do not flatter the text or fill gaps. If the point did not land, report that it did not. A blank or muddled takeaway is the most useful result you can return.
+- Report what you actually extracted, not what you infer the author probably meant.
+
+## What you return
+
+The four items above, plainly, with no preamble.

--- a/stilus/agents/review-voice.md
+++ b/stilus/agents/review-voice.md
@@ -1,0 +1,53 @@
+---
+name: review-voice
+description: Voice critic for the stilus review phase. Give it a piece of prose plus the resolved voice profile. It detects AI slop independently against the deslop catalog, grades each finding 1-5 by severity, reports the density-budget rates, and judges human perception — whether a reader will bail on a wall of text, undefined jargon, filler, or a buried point. Read-only; returns graded, quotation-grounded findings, not edits.
+tools: Read, Grep, Glob
+---
+
+You judge how prose reads — to a person. You detect AI slop and grade how badly each instance hurts, and you judge whether a human reader keeps going or bails. You do not edit, and you do not restate the slop catalog: the patterns, density budgets, and the accuracy-over-precision rule live in the deslop agent (`stilus/agents/deslop.md`), the single source of truth. You apply that catalog and add the severity scale and the human-perception read below.
+
+## What you receive
+
+- The piece: a file path or raw text.
+- The resolved voice profile (project over user over base), so you grade against the intended register, not a generic one.
+
+## What you do
+
+### 1. Detect slop, independently
+
+Run the deslop catalog over the piece yourself; do not assume a prior edit pass caught everything. Measure the density budgets deslop defines (contrast pivots, totalizing quantifiers, disguised lists, echoes) and report the per-1,000-word rates. Flag each instance with the catalog category it matches.
+
+### 2. Grade each finding 1–5
+
+Score every slop finding by how much it costs the reader. Anchor to these levels:
+
+- **1 — Defensible.** A light tell, arguable in context. One stray style word ("robust"), a single mild hedge. Note it; lowest priority.
+- **2 — Minor.** Cut on sight, harmless to meaning. A filler word ("really," "just"), an "in order to," a lone padding phrase.
+- **3 — Noticeable.** A clear machine habit; the reader senses an AI wrote this. A relief structure ("the test suite is the safety net: it catches problems before they ship"), a participial summary tail ("...demonstrating its flexibility"), a tricolon riding for rhythm.
+- **4 — Degrading.** Actively erodes trust or clarity. Stacked tells in one passage, booster register (every result "exciting," every approach "powerful"), a posture declarative standing in for a fact ("We treat both sections as binding").
+- **5 — Reading-stopping.** Empty performance, a wall of words, or meaninglessness a reader bounces off. An overloaded sentence warehousing five facts, a paragraph of pure throat-clearing, a disguised list where every sentence is "thesis: a, b, and c," a point buried under so much scaffolding the reader leaves without it.
+
+When a span fits two levels, grade the higher. Report the distribution (how many of each level).
+
+### 3. Judge human perception
+
+Will a human reader keep going, or bail? Cover:
+
+- **Wall of text** — sentences or paragraphs so long the reader skips them. Name the spans.
+- **Unnecessary jargon** — undefined terms or insider shorthand this audience will not parse.
+- **Meaninglessness** — filler that signals value without delivering it; the reader gets nothing.
+- **Buried or absent point** — a reader who stops early leaves without the takeaway.
+
+Give a one-line "will they keep reading?" verdict and the specific spans that cause drop-off.
+
+## Contracts
+
+- Read-only. You never edit.
+- The slop catalog, density budgets, and accuracy-over-precision rule live in deslop; reference them, do not restate them. The register lives in the voice profile.
+- Ground every finding in a direct quotation from the piece. No quotation, no finding.
+
+## What you return
+
+1. The slop findings, each with: the quoted span, the deslop category, the 1–5 severity, why it costs the reader, and a concrete fix.
+2. The slop severity distribution and the density-budget rates per 1,000 words.
+3. The human-perception read: the keep-reading verdict plus the bail-point spans.

--- a/stilus/commands/review.md
+++ b/stilus/commands/review.md
@@ -1,0 +1,16 @@
+---
+description: Review a finished piece of prose — correctness, voice (graded slop), human perception, and whether an AI reader gets the point. Read-only; produces a scored report, never edits. Usage: /stilus:review <file-or-text>
+---
+
+# /stilus:review
+
+Review the prose the user names — a file path or pasted text — and produce a scored report. You change nothing; this is a read-only assessment.
+
+Run the review phase exactly as defined in this plugin's `context/reviewing.md`:
+
+1. **Gather intent** (purpose, audience, intended point). Ask the user in one prompt; if they supply none, proceed with intent unknown.
+2. **Fan out** to the three specialist agents in parallel — `review-correctness`, `review-voice`, and `review-summary` — following `context/reviewing.md`. Pass the blind summarizer ONLY the prose.
+3. **Synthesize:** run the AI-perception comparison, merge and dedup findings, score each dimension, assign the verdict.
+4. **Deliver** the report in the format from `context/reviewing.md`. Never loop back to revise in standalone mode.
+
+The resolved voice profile, if any, comes from the same scan the write skill uses: project `.claude/rules/voice.md`, then user `~/.claude/rules/voice.md`, then this plugin's `rules/voice.md`.

--- a/stilus/context/authoring-a-voice.md
+++ b/stilus/context/authoring-a-voice.md
@@ -1,0 +1,47 @@
+# Authoring a voice profile
+
+A voice profile teaches stilus to draft in your register instead of a generic one. It lives in `.claude/rules/voice.md` (per project) or `~/.claude/rules/voice.md` (personal default), and extends the plugin base at `stilus/voice.md`.
+
+## What a profile is for
+
+The profile is the additive layer. It says how this author sounds and what they reach for. It does not list banned words or slop patterns — those live in the deslop agent, and the edit phase applies them after drafting. Keep the profile to voice, not to bans.
+
+## Skeleton
+
+Copy this and fill it in. Delete any section you have no opinion on; the base default applies.
+
+```markdown
+---
+extends: stilus/voice.md
+domain: voice
+companion: .claude/context/voice-notes.md
+---
+
+# Voice
+
+## Persona
+One or two sentences: who writes, to whom, with what stance.
+
+## Registers
+### <register name>
+When it is used, and three to five concrete markers (sentence shapes, moves, tics this author owns).
+
+## Preferred and elevated vocabulary
+Words this author reaches for, and the test for when a word earns its place.
+
+## Mode guidance
+### Email
+Opener, body order, length, sign-off.
+### <other modes that matter>
+
+## Additive craft
+Moves specific to this author beyond the base defaults.
+```
+
+## How it resolves
+
+When you run the write skill, stilus reads the project profile, then the user profile, then the base, and merges them section by section with the higher tier winning. It announces which profile it used. The `companion:` field, if present, points at a longer notes file in `.claude/context/` that stilus also reads.
+
+## Keep it honest
+
+Profiles describe a real voice. If you do not have a settled register for a mode, leave it out rather than invent one. The base default is neutral and safe.

--- a/stilus/context/authoring-a-voice.md
+++ b/stilus/context/authoring-a-voice.md
@@ -40,7 +40,7 @@ Moves specific to this author beyond the base defaults.
 
 ## How it resolves
 
-When you run the write skill, stilus reads the project profile, then the user profile, then the base, and merges them section by section with the higher tier winning. It announces which profile it used. The `companion:` field, if present, points at a longer notes file in `.claude/context/` that stilus also reads.
+When stilus resolves your voice, it reads the project profile, then the user profile, then the base, and merges them section by section with the higher tier winning. It announces which profile it used. The `/stilus:review` command resolves your voice this way today (for the `review-voice` specialist); the planned drafting pipeline will read the same profile. The `companion:` field, if present, points at a longer notes file in `.claude/context/` that stilus also reads.
 
 ## Keep it honest
 

--- a/stilus/context/reviewing.md
+++ b/stilus/context/reviewing.md
@@ -1,0 +1,87 @@
+# Reviewing — the stilus review phase
+
+This document is the single source of truth for how stilus reviews a finished piece. The `/stilus:review` command and the write skill's review step both run this flow. It owns synthesis: how the review phase gathers intent, fans out to the specialist agents, compares the blind summary to the intended point, dedups and scores findings, assigns a verdict, and writes the report. The per-dimension rubrics live in the specialist agents, not here.
+
+## The flow
+
+### Step 1 — Gather intent
+
+Establish three things before dispatching:
+
+- **Purpose** — what the piece is for.
+- **Audience** — who reads it.
+- **Intended point** — the one thing the reader should take away.
+
+In the pipeline these come from the drafting context. Standalone, ask the user for them in one prompt. If the user supplies none, proceed with intent unknown: the AI-perception step becomes a mirror (Step 3) rather than a pass/fail.
+
+### Step 2 — Fan out (parallel, read-only)
+
+Dispatch all three specialists on the same target in a single batch so they run concurrently. Each is read-only and independent.
+
+- `review-correctness` — pass the piece and any codebase/domain context.
+- `review-voice` — pass the piece and the resolved voice profile.
+- `review-summary` — pass ONLY the piece. Do not pass the purpose, audience, or intended point. Its blindness is the point.
+
+If the platform namespaces plugin agents, use the namespaced name; the names are unique within this plugin.
+
+### Step 3 — AI perception (synthesis)
+
+Compare `review-summary`'s blind takeaway to the intended point:
+
+- **Intent known:** Did the point survive? Where the blind summary diverges from the intended point — wrong emphasis, missing the main claim, a misread — the prose failed to carry the point to a machine reader. Report the gap as a finding.
+- **Intent unknown:** Present the blind takeaway to the user as a mirror: "An AI reading this cold took away: <summary>. Is that your point?" Do not score this case; surface it for confirmation.
+
+### Step 4 — Merge and dedup
+
+Combine the three findings sets. When two specialists flag the same span (for example, review-voice flags it as a disguised list and review-correctness flags the same span as an unsupported leap), merge into one finding that carries both lenses and the higher severity. Order findings by severity, highest first.
+
+### Step 5 — Score and judge
+
+Score each dimension:
+
+- **Correctness** — PASS if no unsupported claims, contradictions, or disproven facts survive; FAIL if any do. Always attach the claims-to-verify-by-hand list regardless of score.
+- **Voice** — PASS if no slop finding is 4 or 5 and all density budgets are within deslop's limits; CONCERN if the worst finding is 3 or a budget is mildly over; FAIL if any finding is 5 or budgets are well over.
+- **Human perception** — PASS if a reader keeps going; CONCERN if there are isolated bail points; FAIL if the piece reads as a wall of words or the point is buried.
+- **AI perception** — PASS if the blind takeaway matches the intended point; FAIL if it diverges; `mirror` if intent is unknown (unscored).
+
+**Overall verdict:** FAIL if any dimension is FAIL; CONCERN if any is CONCERN and none is FAIL; otherwise PASS. A `mirror` AI-perception result does not by itself raise the verdict.
+
+In the pipeline, a FAIL drives one bounded loop-back to the reviser, then deliver regardless of the second result. Standalone, the verdict is the assessment; never loop.
+
+### Step 6 — Write the report
+
+Use the format below.
+
+## Report format
+
+````
+# Review — <piece>
+
+Verdict: PASS | CONCERN | FAIL
+- Correctness: <PASS/FAIL>
+- Voice: <PASS/CONCERN/FAIL>  (slop: <n>x1 <n>x2 <n>x3 <n>x4 <n>x5)
+- Human perception: <PASS/CONCERN/FAIL>
+- AI perception: <PASS/FAIL/mirror>
+
+## AI perception
+Blind takeaway: <one sentence the cold reader extracted>
+Intended point: <the stated point, or "not supplied">
+<the gap, or "point survived", or the confirm-this-is-your-point prompt>
+
+## Findings (highest severity first)
+1. [voice - severity 4] "<exact quotation>"
+   Why: <reason>
+   Fix: <concrete fix>
+2. [correctness - unsupported] "<exact quotation>"
+   Why: <reason>
+   Fix: <concrete fix>
+...
+
+## Claims to verify by hand
+- "<quoted claim>" — <why it could not be confirmed>
+
+## Density rates (per 1,000 words)
+contrast pivots: <r> | totalizing quantifiers: <r> | disguised lists: <r> | echoes: <r>
+````
+
+Every finding cites a direct quotation from the piece. A finding without a quotation does not ship.

--- a/stilus/context/reviewing.md
+++ b/stilus/context/reviewing.md
@@ -39,8 +39,8 @@ Combine the three findings sets. When two specialists flag the same span (for ex
 
 Score each dimension:
 
-- **Correctness** — PASS if no unsupported claims, contradictions, or disproven facts survive; FAIL if any do. Always attach the claims-to-verify-by-hand list regardless of score.
-- **Voice** — PASS if no slop finding is 4 or 5 and all density budgets are within deslop's limits; CONCERN if the worst finding is 3 or a budget is mildly over; FAIL if any finding is 5 or budgets are well over.
+- **Correctness** — FAIL if any unsupported claim, unsupported leap, contradiction, disproven fact, or action-blocking missing content survives; PASS otherwise. (Non-blocking missing content is a finding, not a FAIL.) Always attach the claims-to-verify-by-hand list regardless of score.
+- **Voice** — PASS if no slop finding is 4 or 5 and all density budgets are within deslop's limits; CONCERN if the worst finding is 3 or 4, or a budget is mildly over; FAIL if any finding is 5 or budgets are well over.
 - **Human perception** — PASS if a reader keeps going; CONCERN if there are isolated bail points; FAIL if the piece reads as a wall of words or the point is buried.
 - **AI perception** — PASS if the blind takeaway matches the intended point; FAIL if it diverges; `mirror` if intent is unknown (unscored).
 

--- a/stilus/context/reviewing.md
+++ b/stilus/context/reviewing.md
@@ -19,7 +19,7 @@ In the pipeline these come from the drafting context. Standalone, ask the user f
 Dispatch all three specialists on the same target in a single batch so they run concurrently. Each is read-only and independent.
 
 - `review-correctness` — pass the piece and any codebase/domain context.
-- `review-voice` — pass the piece and the resolved voice profile.
+- `review-voice` — pass the piece and the resolved voice profile (the base profile if no project or user profile resolves).
 - `review-summary` — pass ONLY the piece. Do not pass the purpose, audience, or intended point. Its blindness is the point.
 
 If the platform namespaces plugin agents, use the namespaced name; the names are unique within this plugin.

--- a/stilus/package.json
+++ b/stilus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stilus",
   "version": "0.1.0",
-  "description": "Stilus — adaptive writing pipeline (write/edit/revise/review) with deslop as the subtractive base",
+  "description": "Stilus — writing tools: the deslop editor, a project voice layer, and a standalone review phase",
   "private": true,
   "license": "MIT"
 }

--- a/stilus/package.json
+++ b/stilus/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "stilus",
+  "version": "0.1.0",
+  "description": "Stilus — adaptive writing pipeline (write/edit/revise/review) with deslop as the subtractive base",
+  "private": true,
+  "license": "MIT"
+}

--- a/stilus/rules/voice.md
+++ b/stilus/rules/voice.md
@@ -1,0 +1,58 @@
+---
+name: voice-base
+domain: voice
+description: Generic voice base for the stilus writing pipeline. Projects extend this with their own register; the Write phase resolves and reads it.
+---
+
+# Voice (generic base)
+
+This file defines the shape of a voice profile and supplies neutral defaults. It carries no personality. The Write phase of stilus reads the resolved voice — project profile over user profile over this base — and drafts in it.
+
+## How a project supplies its voice
+
+Create `.claude/rules/voice.md` in the project (or `~/.claude/rules/voice.md` for a personal default that follows you across repos) with this frontmatter:
+
+```yaml
+---
+extends: stilus/voice.md
+domain: voice
+---
+```
+
+Fill in the sections below. A section you omit falls back to the default here. A section you supply overrides it. Precedence: project profile over user profile over this base.
+
+## What this base does not define
+
+The subtractive catalog (slop patterns, banned constructions, density budgets) and the craft that both drafting and editing share (lead with the point, sentence rhythm, accuracy over precision) live in the deslop agent. This base references them; it never restates them. A voice profile should not restate them either.
+
+## Profile sections
+
+### Persona
+
+Who is writing, in one or two sentences: role, relationship to the audience, the stance the prose takes. Default: a neutral technical author with no personality, who states what a thing does and what it costs.
+
+### Registers
+
+The named registers the author moves between, each with its markers. A project may define one or several. Default: a single neutral analytical register — plain, ordered, unsentimental.
+
+### Preferred and elevated vocabulary
+
+The words this author reaches for, and the rule for when. Default: plain words; no elevated diction.
+
+### Mode guidance
+
+Per-medium conventions. Fill in only the modes that matter.
+
+- Email — opener, body order, length, sign-off. Default: name the recipient, lead with the ask or the answer, keep it short.
+- Slack — Default: one or two sentences, no greeting in active threads.
+- Document or article — Default: topic sentences carry the argument; headers only when the length needs navigation.
+- White paper or report — Default: short paragraphs, argument-driven, specific numbers.
+
+### Additive craft
+
+Positive moves this author makes that deslop does not own:
+
+- Register-driven generation — produce text in the resolved register, not a generic one.
+- Specificity — use the specific number, date, or name when it is available and true.
+- Equip the reader to act — give the reader everything needed to decide without a follow-up round.
+- Analogy as translation — when explaining across domains, map the structure, do not simplify.

--- a/stilus/rules/voice.md
+++ b/stilus/rules/voice.md
@@ -1,12 +1,12 @@
 ---
 name: voice-base
 domain: voice
-description: Generic voice base for the stilus writing pipeline. Projects extend this with their own register; the Write phase resolves and reads it.
+description: Generic voice base for the stilus writing pipeline. Projects extend this with their own register; stilus resolves and reads it when it works in your voice (today the /stilus:review command; the planned drafting pipeline later).
 ---
 
 # Voice (generic base)
 
-This file defines the shape of a voice profile and supplies neutral defaults. It carries no personality. The Write phase of stilus reads the resolved voice — project profile over user profile over this base — and drafts in it.
+This file defines the shape of a voice profile and supplies neutral defaults. It carries no personality. stilus reads the resolved voice — project profile over user profile over this base — when it works in your register: today the `/stilus:review` command resolves it for the review phase, and the planned drafting pipeline will read the same profile.
 
 ## How a project supplies its voice
 


### PR DESCRIPTION
## Summary

Adds **stilus**, a new writing-tools plugin to the claude-domestique marketplace. This branch ships three pieces — the `deslop` editor, a project voice layer, and an orchestrated standalone review phase — with the full Write/Edit/Revise/Review pipeline framed as roadmap.

### What ships
- **`deslop` agent** — subtractive AI-slop removal; single source of truth for the slop catalog.
- **Voice layer** — `rules/voice.md` (neutral base, project-extensible) + `context/authoring-a-voice.md`.
- **Review phase** — an orchestrated, read-only phase exposed via `/stilus:review <file-or-text>`:
  - `review-summary` — blind summarizer (sees only the prose) feeding an AI-perception round-trip
  - `review-voice` — slop graded 1–5 + human-perception read
  - `review-correctness` — internal soundness, verify-when-possible, claims-to-verify-by-hand
  - `context/reviewing.md` — synthesis playbook (intent → fan-out → AI-perception → dedup → scored verdict)
- Marketplace registration (v0.1.0), `bump-version` inclusion, README, CLAUDE.md ownership row + repo tree.

### Design & plans
- Specs: `docs/superpowers/specs/2026-06-18-stilus-writing-plugin-design.md`, `docs/superpowers/specs/2026-06-24-stilus-reviewer-redesign-design.md`
- Plans: `docs/superpowers/plans/2026-06-18-stilus-writing-plugin.md`, `docs/superpowers/plans/2026-06-24-stilus-reviewer-redesign.md`

### Quality
Pure-prompt plugin (no Jest, matching agent-artifex); verification is structural `node -e` checks. Reviewed independently by two models — opus (superpowers review) and codex/gpt-5.5 — with all findings applied, including scoring-logic gaps (severity-4 voice findings, uncovered correctness categories) and doc-honesty fixes.

### Deferred (roadmap)
The `write` skill (Write phase / pipeline orchestrator) and the `reviser` agent (Revise phase) are intentionally not built here; docs describe only shipped scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)