### PR TITLE
chore - verified sends + executor-stamped sender in herd.js (comitatus 0.4.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
       "name": "comitatus",
       "source": "./comitatus",
       "description": "herdr workflows - packages the herdr agent-orchestration skill for claude and codex, auto-injected inside herdr",
-      "version": "0.4.0"
+      "version": "0.4.1"
     },
     {
       "name": "stilus",

--- a/comitatus/__tests__/herd.test.js
+++ b/comitatus/__tests__/herd.test.js
@@ -142,69 +142,122 @@ describe('waitCmd', () => {
   });
 });
 
+describe('resolveSelf', () => {
+  const DATA = { result: { agents: [
+    { name: 'paul', pane_id: 'w1M:p5' },
+    { name: 'cal', pane_id: 'w1M:p4', focused: true },
+  ] } };
+
+  test('override wins over everything', () => {
+    expect(h.resolveSelf(DATA, 'kris', { HERDR_PANE_ID: 'w1M:p5' })).toBe('kris');
+  });
+
+  test('resolves the executing pane from HERDR_PANE_ID, not the focused agent', () => {
+    expect(h.resolveSelf(DATA, undefined, { HERDR_PANE_ID: 'w1M:p5' })).toBe('paul');
+  });
+
+  test('falls back to the focused agent when HERDR_PANE_ID is absent', () => {
+    expect(h.resolveSelf(DATA, undefined, {})).toBe('cal');
+  });
+
+  test('falls back to the focused agent when HERDR_PANE_ID matches no agent', () => {
+    expect(h.resolveSelf(DATA, undefined, { HERDR_PANE_ID: 'w9:p9' })).toBe('cal');
+  });
+});
+
 describe('sendCmd', () => {
-  const list = (focused) => JSON.stringify({ result: { agents: [
-    { name: 'jay', agent: 'claude', pane_id: 'w1:p2' },
-    { name: 'sly', agent: 'claude', pane_id: 'w1:p1', focused: !!focused },
-    { name: 'cod', agent: 'codex', pane_id: 'w1:p3' },
-  ] } });
-  function runner(focused) {
+  // Recipient statuses are served one per `agent list` call so tests can
+  // script the idle->working transition that the submit verification polls for.
+  function runner({ focused, statuses = ['idle'] } = {}) {
     const calls = [];
-    const run = (f, a) => { calls.push([f, ...a]); return (a[0] === 'agent' && a[1] === 'list') ? list(focused) : ''; };
-    return { run, calls };
+    let i = 0;
+    const list = () => {
+      const st = statuses[Math.min(i++, statuses.length - 1)];
+      return JSON.stringify({ result: { agents: [
+        { name: 'jay', agent: 'claude', pane_id: 'w1:p2', agent_status: st },
+        { name: 'sly', agent: 'claude', pane_id: 'w1:p1', focused: !!focused },
+        { name: 'cod', agent: 'codex', pane_id: 'w1:p3', agent_status: st },
+      ] } });
+    };
+    const run = (f, a) => { calls.push([f, ...a]); return (a[0] === 'agent' && a[1] === 'list') ? list() : ''; };
+    const submits = () => calls.filter((c) => c[1] === 'pane' && c[2] === 'send-keys');
+    return { deps: { run, sleep: () => {}, env: {} }, calls, submits };
   }
 
-  test('plain send: resolve pane, send, one Enter (claude recipient)', () => {
-    const { run, calls } = runner();
-    expect(h.sendCmd(['jay', 'rerun the test'], { run }))
-      .toEqual({ result: { type: 'ok' }, pane: 'w1:p2', sent: 'rerun the test' });
-    expect(calls).toEqual([
-      ['herdr', 'agent', 'list'],
-      ['herdr', 'agent', 'send', 'jay', 'rerun the test'],
-      ['herdr', 'pane', 'send-keys', 'w1:p2', 'Enter'],
-    ]);
+  test('plain send: resolve pane, send, Enter, then verify via status poll', () => {
+    const { deps, calls, submits } = runner({ statuses: ['idle', 'idle', 'idle', 'working'] });
+    expect(h.sendCmd(['jay', 'rerun the test'], deps))
+      .toEqual({ result: { type: 'ok' }, pane: 'w1:p2', sent: 'rerun the test', submitted: true });
+    expect(calls).toContainEqual(['herdr', 'agent', 'send', 'jay', 'rerun the test']);
+    expect(submits()).toEqual([['herdr', 'pane', 'send-keys', 'w1:p2', 'Enter']]);
   });
 
   test('codex recipient gets two Enters via submitKeys', () => {
-    const { run, calls } = runner();
-    h.sendCmd(['cod', 'hello'], { run });
-    expect(calls.filter((c) => c[1] === 'pane' && c[2] === 'send-keys')).toEqual([
+    const { deps, submits } = runner({ statuses: ['idle', 'idle', 'idle', 'working'] });
+    h.sendCmd(['cod', 'hello'], deps);
+    expect(submits()).toEqual([
       ['herdr', 'pane', 'send-keys', 'w1:p3', 'Enter'],
       ['herdr', 'pane', 'send-keys', 'w1:p3', 'Enter'],
     ]);
   });
 
+  test('dropped submit is retried until the recipient starts working', () => {
+    // attempt 1: all 4 polls stay idle (Enter was swallowed); attempt 2 lands.
+    const statuses = ['idle', 'idle', 'idle', 'idle', 'idle', 'idle', 'idle', 'working'];
+    const { deps, submits } = runner({ statuses });
+    expect(h.sendCmd(['cod', 'hello'], deps).submitted).toBe(true);
+    expect(submits()).toHaveLength(4); // 2 Enters x 2 attempts
+  });
+
+  test('reports submitted:false when the recipient never starts working', () => {
+    const { deps, submits } = runner({ statuses: ['idle'] });
+    expect(h.sendCmd(['cod', 'hello'], deps).submitted).toBe(false);
+    expect(submits()).toHaveLength(6); // 2 Enters x 3 attempts, then give up
+  });
+
+  test('fast turn (idle->done between polls) still counts as submitted', () => {
+    const { deps, submits } = runner({ statuses: ['idle', 'idle', 'idle', 'done'] });
+    expect(h.sendCmd(['jay', 'quick one'], deps).submitted).toBe(true);
+    expect(submits()).toHaveLength(1);
+  });
+
   test('--reply --from stamps the compact protocol header', () => {
-    const { run, calls } = runner();
-    expect(h.sendCmd(['jay', 'status?', '--reply', '--from', 'sly'], { run }).sent)
+    const { deps, calls } = runner({ statuses: ['working'] });
+    expect(h.sendCmd(['jay', 'status?', '--reply', '--from', 'sly'], deps).sent)
       .toBe('[from sly reply] status?');
     expect(calls).toContainEqual(['herdr', 'agent', 'send', 'jay', '[from sly reply] status?']);
   });
 
-  test('--fyi resolves <self> from the focused agent when --from is omitted', () => {
-    const { run } = runner(true); // sly is focused
-    expect(h.sendCmd(['jay', 'heads up', '--fyi'], { run }).sent).toBe('[from sly fyi] heads up');
+  test('--fyi resolves <self> from the executing pane, not the focused agent', () => {
+    const { deps } = runner({ focused: true, statuses: ['working'] }); // focus drifted to sly
+    deps.env = { HERDR_PANE_ID: 'w1:p2' }; // but jay is running the send
+    expect(h.sendCmd(['cod', 'heads up', '--fyi'], deps).sent).toBe('[from jay fyi] heads up');
+  });
+
+  test('--fyi falls back to the focused agent when --from and HERDR_PANE_ID are absent', () => {
+    const { deps } = runner({ focused: true, statuses: ['working'] }); // sly is focused
+    expect(h.sendCmd(['jay', 'heads up', '--fyi'], deps).sent).toBe('[from sly fyi] heads up');
   });
 
   test('does not double-prefix an already [from ...] message', () => {
-    const { run } = runner(true);
-    expect(h.sendCmd(['jay', '[from sly reply] hi', '--reply'], { run }).sent).toBe('[from sly reply] hi');
+    const { deps } = runner({ focused: true, statuses: ['working'] });
+    expect(h.sendCmd(['jay', '[from sly reply] hi', '--reply'], deps).sent).toBe('[from sly reply] hi');
   });
 
   test('throws on unknown handle', () => {
-    const { run } = runner();
-    expect(() => h.sendCmd(['ghost', 'hi'], { run })).toThrow(/no agent: ghost/);
+    const { deps } = runner();
+    expect(() => h.sendCmd(['ghost', 'hi'], deps)).toThrow(/no agent: ghost/);
   });
 
   test('--reply with no focused agent and no --from throws (no silent mis-stamp)', () => {
-    const { run } = runner(); // no agent is focused
-    expect(() => h.sendCmd(['jay', 'hi', '--reply'], { run }))
+    const { deps } = runner(); // no agent is focused
+    expect(() => h.sendCmd(['jay', 'hi', '--reply'], deps))
       .toThrow(/cannot resolve sender handle/);
   });
 
   test('--from without a value throws instead of being silently ignored', () => {
-    const { run } = runner(true);
-    expect(() => h.sendCmd(['jay', 'hi', '--reply', '--from'], { run })).toThrow(/--from needs a value/);
+    const { deps } = runner({ focused: true });
+    expect(() => h.sendCmd(['jay', 'hi', '--reply', '--from'], deps)).toThrow(/--from needs a value/);
   });
 });
 
@@ -322,6 +375,24 @@ describe('dispatch routes action verbs', () => {
   });
 });
 
+describe('usage / --help', () => {
+  test('send --help prints usage instead of resolving --help as a handle', () => {
+    const calls = [];
+    const deps = { run: (f, a) => { calls.push([f, ...a]); return '{}'; } };
+    const out = h.dispatch(['send', '--help'], {}, deps);
+    expect(out).toMatch(/usage: herd\.js/);
+    expect(calls).toEqual([]); // short-circuits before `herdr agent list`
+  });
+  test('bare --help, -h, and no verb print usage', () => {
+    expect(h.dispatch(['--help'], {}, {})).toMatch(/usage: herd\.js/);
+    expect(h.dispatch(['-h'], {}, {})).toMatch(/usage: herd\.js/);
+    expect(h.dispatch([], {}, {})).toMatch(/usage: herd\.js/);
+  });
+  test('usage warns that the native wait takes a single status, not a comma list', () => {
+    expect(h.usage()).toMatch(/herdr wait agent-status.*one\b/i);
+  });
+});
+
 describe('herd.js main wiring (child process)', () => {
   const path = require('path');
   const { execFileSync } = require('child_process');
@@ -334,5 +405,9 @@ describe('herd.js main wiring (child process)', () => {
     expect(err).toBeDefined();
     expect(err.status).toBe(1);
     expect(String(err.stderr)).toMatch(/^herd: unknown command/m);
+  });
+  test('send --help exits 0 with usage on stdout', () => {
+    const out = execFileSync('node', [HERD, 'send', '--help'], { encoding: 'utf8', stdio: 'pipe', input: '' });
+    expect(out).toMatch(/usage: herd\.js/);
   });
 });

--- a/comitatus/package.json
+++ b/comitatus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@claude-domestique/comitatus",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "herdr workflows plugin for Claude Code - packages the herdr skill, auto-injected inside herdr",
   "main": "hooks/herdr-orient.js",
   "scripts": {

--- a/comitatus/skills/herdr/SKILL.md
+++ b/comitatus/skills/herdr/SKILL.md
@@ -202,7 +202,7 @@ the handle is also the pane label. the decorated **tab** label (step 3) does **n
 
 ### 5. message another agent by handle
 
-the one-call path: `node "$H" send <handle> <msg>` resolves the pane, sends, and submits with the model-correct keys (codex gets two Enters via `submit-keys`). add `--reply` or `--fyi` to stamp the protocol flag (below):
+the one-call path: `node "$H" send <handle> <msg>` resolves the pane, sends, submits with the model-correct keys (codex gets two Enters via `submit-keys`), then **verifies** the submit landed - it polls the recipient's `agent_status` for the `working` transition and resends the keys on a miss (a blind Enter races the recipient TUI's ingest; slow composers like codex swallow it). the result reports `"submitted":true|false` - `false` means the recipient never started a turn, so resend. add `--reply` or `--fyi` to stamp the protocol flag (below):
 
 ```bash
 : "${H:?set H from the herdr orientation line before piping herdr JSON into node}"
@@ -233,7 +233,7 @@ hsend() {  # hsend <handle> <one-line-message>
 }
 ```
 
-the submit gesture is dropped only if `jay` was mid-generation (`working`); if no reply comes back, resend. for replies, seeding, roster, and how to handle no-reply messages, see the from/to protocol below.
+a raw `pane send-keys` submit (this manual path and `hsend`) is fire-and-forget: it drops if `jay` was mid-generation (`working`), and it can race the recipient TUI's ingest of the just-typed text - codex composers lose that race intermittently, leaving the message sitting unsubmitted. `node "$H" send` closes both gaps by verifying the status transition and retrying; on the manual path, if no reply comes back, resend. for replies, seeding, roster, and how to handle no-reply messages, see the from/to protocol below.
 
 ### 6. close agents on a worktree
 
@@ -314,7 +314,7 @@ a stateless convention for agents to message each other and reply, without scrap
 [from <self> fyi]   <body>     # no reply expected - do NOT reply
 ```
 
-`<self>` is your handle; reply to `<self>` with `[from <you> ...] <answer>`. a newline submits the turn early, so keep every message to one line. `node "$H" send` / `send-wait-read` stamp this flag for you: `--reply` -> `[from <self> reply]`, `--fyi` -> `[from <self> fyi]`. they resolve `<self>` from the *focused* pane, which is you when you run it in your own pane; if you ever drive a send from a different pane, pass `--from <self>` so the sender is stamped correctly.
+`<self>` is your handle; reply to `<self>` with `[from <you> ...] <answer>`. a newline submits the turn early, so keep every message to one line. `node "$H" send` / `send-wait-read` stamp this flag for you: `--reply` -> `[from <self> reply]`, `--fyi` -> `[from <self> fyi]`. they resolve `<self>` from the *executing* pane (`$HERDR_PANE_ID`, which your subprocesses inherit), so scripted and background sends stamp the right sender even when UI focus has drifted elsewhere; the focused pane is only a fallback when that env var is missing. pass `--from <self>` to override.
 
 **send to teammate `<to>`:**
 
@@ -324,7 +324,7 @@ TO=jay
 node "$H" send "$TO" "<body>" --reply   # stamps [from <self> reply], resolves the pane, submits
 ```
 
-**push and let the reply confirm - don't pre-check.** the submit gesture is dropped only if the recipient was `working`; its `[from <to>]` reply landing in your pane means it arrived, and *no* reply means resend. only a message that expects **no** reply (e.g. a `[herd ...]` directive) has nothing to confirm it - then send when the recipient is not `working`, or read its pane to verify:
+**push and let the reply confirm - don't pre-check.** `node "$H" send` verifies the submit against the recipient's `agent_status` and retries, reporting `"submitted":false` when it never landed; its `[from <to>]` reply landing in your pane means it arrived, and *no* reply means resend. only a message that expects **no** reply (e.g. a `[herd ...]` directive) has nothing to confirm it - then send when the recipient is not `working`, or read its pane to verify:
 
 ```bash
 # wait until the recipient is free to receive (idle OR done), not mid-generation:
@@ -355,7 +355,7 @@ seed the rule into every orientation: "periodically reconcile your roster agains
 **delivery reliability (validated by testing):**
 
 - **`agent send` returns `ok` for *typed*, not *delivered*.** the `{"result":{"type":"ok"}}` ack means the text reached the recipient's input buffer; it does **not** mean the agent saw it. submitting is a separate `pane send-keys` call; guard `H`, then use `node "$H" submit-keys <handle>` (or the `hsend` helper) so codex gets its required second Enter. until then the message sits unsubmitted in the prompt. treat the reply, not the `ok`, as proof of delivery.
-- **the reply, or its absence, is the signal.** push the message and let the reply confirm it - a `[from <to>]` turn landing in your pane means it arrived; nothing landing means the submit gesture dropped (the recipient was `working`), so resend. you don't pre-check the recipient for reply-expecting messages.
+- **the reply, or its absence, is the signal.** push the message and let the reply confirm it - a `[from <to>]` turn landing in your pane means it arrived; nothing landing means the submit gesture dropped (the recipient was `working`, or a raw send-keys lost the ingest race), so resend. `node "$H" send` retries the race for you and reports `"submitted"`; you don't pre-check the recipient for reply-expecting messages.
 - **no-reply messages need a check.** a directive that expects no reply (`[herd ...]`, a one-way note) has nothing to confirm delivery, so send it when the recipient is not `working` (poll) or read its pane to verify - reliable `agent_status` is what makes the poll checkable, so a broken integration (see the opencode status fix) breaks it. (roster directives tolerate drops anyway: peer-detection re-discovers a missed add/remove.)
 - **pre-authorize `herdr`.** an agent that prompts for per-command tool approval before running `herdr ...` stalls mid-protocol. allowlist `herdr` in each agent's tool-permission config (the legacy herdr-mate pre-authorized its send wrapper for exactly this).
 - **weak local models narrate, not execute.** small models (e.g. qwen2.5:7b) print the CLI as text instead of running it; they need an explicit "run these as real shell commands - do not print," and often a capable peer to coach them. the protocol is reliable between capable agents (claude/codex) and best-effort with weak ones.
@@ -387,8 +387,9 @@ herdr wait agent-status w9:p1 --status done --timeout 120000   # a sibling finis
 ## gotchas
 
 - **fetch before `worktree create`** - `--base origin/main` is the local ref; it is stale until you `git fetch origin main`.
-- **`agent send` returns `ok` for *typed*, not *submitted*, and sends no Enter** - the `ok` ack only means the text reached the input buffer; the message sits unsubmitted until you submit it (`pane send-keys <pane> $(herdr agent list | node "$H" submit-keys <handle>)`, dropped only while the target is `working`). guard `H`, then pair every send with the helper-driven submit keys - or use the `hsend` helper (step 5) - and let the reply confirm it landed (resend on silence); only for a no-reply message poll until the target is not `working` first, or verify by reading its pane. don't hard-code one global Enter count.
-- **codex TUI submit gotcha** - codex panes require a second Enter after `agent send` in cases where other agents submit with one. guard `H`, then use `node "$H" submit-keys <handle>` so codex gets `Enter Enter` and other agents get `Enter`; if a long codex send still goes silent, retry as shorter one-line chunks.
+- **`agent send` returns `ok` for *typed*, not *submitted*, and sends no Enter** - the `ok` ack only means the text reached the input buffer; the message sits unsubmitted until you submit it (`pane send-keys <pane> $(herdr agent list | node "$H" submit-keys <handle>)`). prefer `node "$H" send <handle> <msg>`, which submits *and* verifies via the recipient's `agent_status`, retrying on a miss and reporting `"submitted"`; let the reply confirm delivery (resend on silence). only for a no-reply message poll until the target is not `working` first, or verify by reading its pane. don't hard-code one global Enter count.
+- **codex TUI submit gotchas** - codex panes require a second Enter where other agents submit with one, *and* their composer ingests typed text slowly enough that an immediate Enter is swallowed intermittently (a raw `agent send` + `send-keys` pair silently drops ~2 in 3 messages). `node "$H" send` handles both (model-correct keys + verified, retried submit); if a long codex send still goes silent, retry as shorter one-line chunks.
+- **`--status` comma lists are helper-only** - `node "$H" wait <handle> --status idle,done` accepts a comma-separated set, but the native `herdr wait agent-status <pane>` takes exactly one status; passing it a comma list doesn't match anything. use the helper when you need "idle OR done".
 - **opencode status needs the fix plugin** - herdr 0.7.0's managed opencode integration is out of date with opencode 1.17.8 (object-form `session.status` + fire-and-forget idle), so opencode agents get stuck `working` / never report state right. the sibling plugin `~/.config/opencode/plugins/herdr-opencode-status-fix.js` restores correct working/idle/blocked reporting. without it, `wait agent-status` on an opencode pane is unreliable.
 - **only the home repo's worktree tree nests; plain workspaces don't** - the sidebar nests exactly one repo group (main checkout -> its linked worktrees -> tabs), keyed on `repo_root`. a `workspace create --cwd` workspace gets **no** repo association and floats ungrouped, even at a repo root. give each agent in a herd a *tab* in the herd's one workspace; make the herd a worktree if you want it to nest under the repo's main checkout.
 - **workspace label vs tab truncation** - agent rows render as `<workspace> · <tab>`, and herdr labels a worktree's workspace with its (long) directory name, so the decorated `<handle> <glyph>` tab label can truncate in the collapsed sidebar; the handle reappears on focus/widen. that label is herdr's default - you don't rename it (see `## naming`).

--- a/comitatus/skills/herdr/scripts/herd.js
+++ b/comitatus/skills/herdr/scripts/herd.js
@@ -75,9 +75,14 @@ function waitCmd(args, deps) {
   }
 }
 
-function resolveSelf(data, override) {
+function resolveSelf(data, override, env = process.env) {
   if (override) return override;
-  const a = agentList(data).find((x) => x && x.focused && x.name);
+  // The executing pane is the identity source: focus is a global that drifts
+  // on any human click, which mislabels scripted sends (misroutes replies).
+  const mine = env.HERDR_PANE_ID
+    && agentList(data).find((x) => x && x.pane_id === env.HERDR_PANE_ID && x.name);
+  if (mine) return mine.name;
+  const a = agentList(data).find((x) => x && x.focused && x.name); // legacy fallback
   return a ? a.name : undefined;
 }
 
@@ -103,15 +108,41 @@ function sendCmd(args, deps) {
 
   let body = message;
   if (reply || fyi) {
-    const self = resolveSelf(data, fromOverride);
+    const self = resolveSelf(data, fromOverride, deps.env);
     if (!self) throw new Error('cannot resolve sender handle (pass --from <self>)');
     body = stampPrefix(message, self, reply ? 'reply' : 'fyi');
   }
 
   deps.run('herdr', ['agent', 'send', handle, body]);
-  // model-aware submit (codex needs two Enters; #138 submitKeys)
-  for (const k of submitKeys(data, handle)) deps.run('herdr', ['pane', 'send-keys', p, k]);
-  return { result: { type: 'ok' }, pane: p, sent: body };
+  const submitted = submitWithVerify(p, handle, deps);
+  return { result: { type: 'ok' }, pane: p, sent: body, submitted };
+}
+
+// A blind Enter races the recipient TUI's ingest of the just-typed text: slow
+// composers (codex) swallow it and the message sits unsubmitted while the
+// sender sees ok. Fire the model-aware submit keys (#138), then verify via the
+// agent_status transition — the composer buffer lags the status flip, so
+// status, not a pane read, is the reliable signal — and resend on a miss.
+// Returns false if still unconfirmed after all attempts (the message may be
+// sitting unsubmitted). A recipient already `working` at entry is ambiguous —
+// our submit is indistinguishable from its in-flight turn, so the result is
+// optimistic there; don't send to a working peer.
+function submitWithVerify(p, handle, deps, opts = {}) {
+  const attempts = opts.attempts || 3;
+  const polls = opts.polls || 4;
+  const pollMs = opts.pollMs || 750;
+  const before = status(loadAgentList({}, deps), handle);
+  for (let a = 0; a < attempts; a++) {
+    const data = loadAgentList({}, deps);
+    for (const k of submitKeys(data, handle)) deps.run('herdr', ['pane', 'send-keys', p, k]);
+    for (let i = 0; i < polls; i++) {
+      deps.sleep(pollMs);
+      const now = status(loadAgentList({}, deps), handle);
+      if (now === 'working') return true; // started our turn
+      if (before !== 'working' && now !== before && now !== 'unknown') return true; // fast turn, e.g. idle->done
+    }
+  }
+  return false;
 }
 
 function sendWaitReadCmd(args, deps) {
@@ -152,8 +183,32 @@ function agentCmd(args, deps) {
   return { handle: a.handle, model: a.model, pane_id: paneId, tab };
 }
 
+function usage() {
+  return [
+    'usage: herd.js <verb> [args]',
+    '',
+    'stdin verbs (pipe `herdr agent list` in, or let the helper fetch it):',
+    '  pane <handle>                    pane_id for a handle',
+    '  status <handle|pane>             agent_status',
+    '  members [--workspace <ws>]       handles, optionally per workspace',
+    '  field <dot.path>                 extract a field from piped JSON',
+    '  submit-keys <handle|pane>        model-correct submit gesture',
+    '',
+    'action verbs (run herdr themselves):',
+    '  wait <handle> [--status a,b] [--timeout ms] [--interval ms]',
+    '      poll until status matches; comma lists work HERE only -',
+    '      the native `herdr wait agent-status` takes exactly one status',
+    '  send <handle> <msg> [--reply|--fyi] [--from <self>]',
+    '      type, submit, verify; result reports "submitted":true|false',
+    '  send-wait-read <handle> <msg> [--timeout ms] [--lines n]',
+    '  agent <model> <handle> --workspace <ws> --cwd <dir> [--timeout ms] [--label s]',
+    '  up [...]                         one-shot worktree + herd launcher',
+  ].join('\n');
+}
+
 function dispatch(argv, data, deps) {
   const [cmd, ...rest] = argv;
+  if (!cmd || cmd === '--help' || cmd === '-h' || rest[0] === '--help') return usage();
   switch (cmd) {
     case 'pane':
       return pane(loadAgentList(data, deps), rest[0]);
@@ -218,6 +273,12 @@ async function main() {
     }
     return;
   }
+  // help never needs stdin; answer before readStdin so an interactive
+  // `herd.js send --help` doesn't sit waiting for EOF
+  if (!argv[0] || argv[0] === '--help' || argv[0] === '-h' || argv[1] === '--help') {
+    process.stdout.write(usage() + '\n');
+    return;
+  }
   const raw = await readStdin();
   let data;
   try {
@@ -251,10 +312,12 @@ module.exports = {
   resolveSelf,
   stampPrefix,
   sendCmd,
+  submitWithVerify,
   sendWaitReadCmd,
   agentCmd,
   defaultDeps,
   getField,
   dispatch,
   format,
+  usage,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
     },
     "comitatus": {
       "name": "@claude-domestique/comitatus",
-      "version": "0.2.0",
+      "version": "0.4.1",
       "license": "MIT",
       "devDependencies": {
         "jest": "^30.2.0",


### PR DESCRIPTION
## Summary

Fixes two high-severity silent message-loss bugs in the herdr `send` path (from a field bug report validated live against a Codex peer), plus the two lower-priority papercuts from the same report.

### Bug 1: blind submit drops messages to codex peers
`sendCmd` typed the message, fired the submit key(s) with zero delay, and returned `ok`. Whether the Enter landed before the recipient TUI finished ingesting the text is a race — codex composers lost it ~2/3 of the time, leaving the message sitting unsubmitted while the sender believed it was delivered. Claude recipients ingest fast enough to mask the bug.

**Fix:** new `submitWithVerify` fires the model-correct keys, polls the recipient's `agent_status` for the `working` transition (status, not a composer scrape — the buffer lags the status flip), and resends on a miss (3 attempts x 4 polls x 750ms). The `send` result now reports `"submitted":true|false`. Fast turns (`idle->done` between polls) count as submitted; a recipient already `working` at entry is inherently ambiguous and reported optimistically (existing doctrine: don't send to a working peer).

### Bug 2: `--reply`/`--fyi` stamp the wrong sender
`resolveSelf` derived `<self>` from the UI-focused pane. Focus is a global that drifts on any click, so a batch of scripted sends could stamp different senders mid-batch and misroute replies to uninvolved agents (observed: 3 of 5 replies to the wrong agent).

**Fix:** `<self>` resolves from the executing pane via `$HERDR_PANE_ID` (inherited by the helper subprocess), falling back to focus only when absent. `--from` still overrides.

### Papercuts
- `send --help` resolved `--help` as a handle (`no agent: --help`). `herd.js` now prints usage for `--help`/`-h`/no verb, answered before reading stdin so interactive invocations don't hang.
- Helper `wait` accepts comma `--status idle,done` but the native `herdr wait agent-status` takes exactly one status — now called out in the usage text and a SKILL.md gotcha.

### Docs
SKILL.md updated where it documented the old behavior: the focused-pane `<self>` resolution, the "submit drops only while `working`" claim (the ingest race disproves it), and the codex submit gotcha.

## Test plan
- 10 new Jest tests (TDD: watched each fail against the old code): dropped-submit retry, `submitted:false` after all attempts, fast-turn detection, focus-drifted sender stamping, `HERDR_PANE_ID` resolution + fallbacks, help short-circuits
- Full comitatus suite: 107/107 passing
- Implementation diffed against the live-validated patch from the reporting machine: logic identical (upstream adds env injection for tests + the help/usage handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MUXRkC2QsSRix4qbt9u5e